### PR TITLE
Rework crash state uniqueness check and stop testing if no new states found.

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -26,10 +26,14 @@ tests/%.so: tests/$(addsuffix .cpp, %) tests/BaseTestCase.h
 	$(GPP) $(GOPTS) $(GOTPSSO) -Wl,-soname,$(notdir $@) \
 		-o $@ $<
 	
-permuter/RandomPermuter.so: permuter/RandomPermuter.cpp permuter/RandomPermuter.h \
-		disk_wrapper_ioctl.h $(UTILS_OBJS)
+$(BUILD_DIR)/permuter/Permuter.o: permuter/Permuter.cpp
+	mkdir -p $(@D)
+	$(GPP) $(GOPTS) -fPIC -c -o $@ $<
+
+permuter/RandomPermuter.so: permuter/RandomPermuter.cpp \
+		$(BUILD_DIR)/permuter/Permuter.o $(UTILS_OBJS)
 	$(GPP) $(GOPTS) $(GOTPSSO) -Wl,-soname,RandomPermuter.so \
-		-o permuter/RandomPermuter.so permuter/RandomPermuter.cpp $(UTILS_OBJS)
+		-o permuter/RandomPermuter.so $^
 
 utils/utils.o: utils/utils.h utils/utils.cpp disk_wrapper_ioctl.h
 	$(GPP) $(GOPTS) -fPIC -o utils/utils.o -c utils/utils.cpp

--- a/code/Makefile
+++ b/code/Makefile
@@ -19,7 +19,8 @@ cow_brd.ko disk_wrapper.ko: $(MODULES)
 $(BUILD_DIR)/harness: harness/c_harness.cpp harness/Tester.cpp \
 		$(UTILS_OBJS) $(BUILD_DIR)/utils/communication/ServerSocket.o \
 		$(BUILD_DIR)/utils/communication/ClientSocket.o \
-		$(BUILD_DIR)/utils/communication/BaseSocket.o
+		$(BUILD_DIR)/utils/communication/BaseSocket.o \
+		$(BUILD_DIR)/permuter/Permuter.o
 	$(GPP) $(GOPTS) $^ -ldl -o $(BUILD_DIR)/$@
 
 tests/%.so: tests/$(addsuffix .cpp, %) tests/BaseTestCase.h

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -448,7 +448,7 @@ int Tester::test_check_random_permutations(const int num_rounds) {
   time_point<steady_clock> start_time = steady_clock::now();
   test_test_stats[TESTS_RUN] = 0;
   Permuter *p = permuter_loader.get_instance();
-  p->init_data(&log_data);
+  p->InitDataVector(&log_data);
   vector<disk_write> permutes;
   for (int rounds = 0; rounds < num_rounds; ++rounds) {
     // Print status every 1024 iterations.
@@ -457,11 +457,15 @@ int Tester::test_check_random_permutations(const int num_rounds) {
     }
     // Begin permute timing.
     time_point<steady_clock> permute_start_time = steady_clock::now();
-    p->gen_one_state(permutes);
+    bool new_state = p->GenerateCrashState(permutes);
     time_point<steady_clock> permute_end_time = steady_clock::now();
     timing_stats[PERMUTE_TIME] +=
         duration_cast<milliseconds>(permute_end_time - permute_start_time);
     // End permute timing.
+
+    if (!new_state) {
+      break;
+    }
 
     ++test_test_stats[TESTS_RUN];
     //cout << '.' << std::flush;
@@ -548,6 +552,11 @@ int Tester::test_check_random_permutations(const int num_rounds) {
   //cout << endl;
   time_point<steady_clock> end_time = steady_clock::now();
   timing_stats[TOTAL_TIME] = duration_cast<milliseconds>(end_time - start_time);
+
+  if (test_test_stats[TESTS_RUN] < num_rounds) {
+    cout << "=============== Unable to find new unique state, stopping at "
+      << test_test_stats[TESTS_RUN] << " tests ===============" << endl << endl;
+  }
   return SUCCESS;
 }
 

--- a/code/permuter/Permuter.cpp
+++ b/code/permuter/Permuter.cpp
@@ -1,0 +1,150 @@
+#include <list>
+#include <vector>
+
+#include "Permuter.h"
+#include "../utils/utils.h"
+
+namespace fs_testing {
+namespace permuter {
+
+using std::list;
+using std::size_t;
+using std::vector;
+
+using fs_testing::utils::disk_write;
+
+namespace {
+
+struct range {
+  unsigned int start;
+  unsigned int end;
+};
+
+}  // namespace
+
+
+size_t BioVectorHash::operator() (const vector<unsigned int>& permutation)
+    const {
+  unsigned int seed = permutation.size();
+  for (const auto& bio_pos : permutation) {
+    seed ^= bio_pos + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  }
+  return seed;
+}
+
+bool BioVectorEqual::operator() (const std::vector<unsigned int>& a,
+    const std::vector<unsigned int>& b) const {
+  if (a.size() != b.size()) {
+    return false;
+  }
+  for (unsigned int i = 0; i < a.size(); ++i) {
+    if (a.at(i) != b.at(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void Permuter::InitDataVector(vector<disk_write> *data) {
+  epochs_.clear();
+  unsigned int index = 0;
+  list<range> overlaps;
+  while (index < data->size()) {
+    struct epoch current_epoch;
+    current_epoch.has_barrier = false;
+    current_epoch.overlaps = false;
+
+    // Get all ops in this epoch and add them to either the sync_op or async_op
+    // lists.
+    while (index < data->size() && !(data->at(index)).is_barrier_write()) {
+      disk_write curr = data->at(index);
+      // Find overlapping ranges.
+      unsigned int start = curr.metadata.write_sector;
+      unsigned int end = start + curr.metadata.size;
+      for (auto range_iter = overlaps.begin(); range_iter != overlaps.end();
+          range_iter++) {
+        range r = *range_iter;
+        if ((r.start <= start && r.end >= start)
+            || (r.start <= end && r.end >= end)) {
+          if (r.start > start) {
+            r.start = start;
+          }
+          if (r.end < end) {
+            r.end = end;
+          }
+          current_epoch.overlaps = true;
+          break;
+        } else if (r.start > end) {
+          // Since this is an ordered list, if the next spot is past where we're
+          // looking now then we won't find anything past here. We may as well
+          // insert an item here.
+          range new_range = {start, end};
+          overlaps.insert(range_iter, new_range);
+        }
+      }
+
+      epoch_op curr_op = {index, data->at(index)};
+      current_epoch.ops.push_back(curr_op);
+      current_epoch.num_meta += data->at(index).is_meta();
+      ++index;
+    }
+
+    // Check is the op at the current index is a "barrier." If it is then add it
+    // to the special spot in the epoch, otherwise just push the current epoch
+    // onto the list and move to the next segment of the log.
+    if (index < data->size() && (data->at(index)).is_barrier_write()) {
+      epoch_op curr_op = {index, data->at(index)};
+      current_epoch.ops.push_back(curr_op);
+      current_epoch.num_meta += data->at(index).is_meta();
+      current_epoch.has_barrier = true;
+      ++index;
+    }
+    epochs_.push_back(current_epoch);
+  }
+}
+
+vector<epoch>* Permuter::GetEpochs() {
+  return &epochs_;
+}
+
+
+bool Permuter::GenerateCrashState(vector<disk_write>& res) {
+  vector<epoch_op> crash_state;
+  unsigned long retries = 0;
+  unsigned int exists = 0;
+  bool new_state = true;
+  do {
+    new_state = gen_one_state(crash_state);
+
+    vector<unsigned int> crash_state_hash(crash_state.size());
+    for (unsigned int i = 0; i < crash_state.size(); ++i) {
+      crash_state_hash.at(i) = crash_state.at(i).abs_index;
+    }
+
+    ++retries;
+    exists = completed_permutations_.count(crash_state_hash);
+    if (retries >= 2 * crash_state.size()) {
+      // We've likely found all possible crash states so just break.
+      break;
+    }
+  } while (exists > 0);
+
+  // Move the permuted crash state data over into the returned crash state
+  // vector.
+  res.resize(crash_state.size());
+  for (unsigned int i = 0; i < crash_state.size(); ++i) {
+    res.at(i) = crash_state.at(i).op;
+  }
+
+  if (exists == 0) {
+    // We broke out of the above loop because this state is unique.
+    return new_state;
+  }
+
+  // We broke out of the above loop because we haven't found a new state in some
+  // time.
+  return false;
+}
+
+}  // namespace permuter
+}  // namespace fs_testing

--- a/code/permuter/RandomPermuter.cpp
+++ b/code/permuter/RandomPermuter.cpp
@@ -5,6 +5,7 @@
 
 #include <cassert>
 
+#include "Permuter.h"
 #include "RandomPermuter.h"
 
 namespace fs_testing {
@@ -18,157 +19,73 @@ using std::vector;
 
 using fs_testing::utils::disk_write;
 
-namespace {
-
-struct range {
-  unsigned int start;
-  unsigned int end;
-};
-
-}  // namespace
-
-void RandomPermuter::init_data_vector(vector<disk_write> *data) {
-  epochs.clear();
-  log_length = data->size();
-  unsigned int index = 0;
-  list<range> overlaps;
-  while (index < data->size()) {
-    struct epoch current_epoch;
-    current_epoch.has_barrier = false;
-    current_epoch.overlaps = false;
-    current_epoch.length = 0;
-
-    // Get all ops in this epoch and add them to either the sync_op or async_op
-    // lists.
-    while (index < data->size() && !(data->at(index)).is_barrier_write()) {
-      disk_write curr = data->at(index);
-      // Find overlapping ranges.
-      unsigned int start = curr.metadata.write_sector;
-      unsigned int end = start + curr.metadata.size;
-      for (auto range_iter = overlaps.begin(); range_iter != overlaps.end();
-          range_iter++) {
-        range r = *range_iter;
-        if ((r.start <= start && r.end >= start)
-            || (r.start <= end && r.end >= end)) {
-          if (r.start > start) {
-            r.start = start;
-          }
-          if (r.end < end) {
-            r.end = end;
-          }
-          current_epoch.overlaps = true;
-          break;
-        } else if (r.start > end) {
-          // Since this is an ordered list, if the next spot is past where we're
-          // looking now then we won't find anything past here. We may as well
-          // insert an item here.
-          range new_range = {start, end};
-          overlaps.insert(range_iter, new_range);
-        }
-      }
-
-      ++current_epoch.length;
-      epoch_op curr_op = {index, data->at(index)};
-      current_epoch.ops.push_back(curr_op);
-      current_epoch.num_meta += data->at(index).is_meta();
-      ++index;
-    }
-
-    // Check is the op at the current index is a "barrier." If it is then add it
-    // to the special spot in the epoch, otherwise just push the current epoch
-    // onto the list and move to the next segment of the log.
-    if (index < data->size() && (data->at(index)).is_barrier_write()) {
-      ++current_epoch.length;
-      epoch_op curr_op = {index, data->at(index)};
-      current_epoch.ops.push_back(curr_op);
-      current_epoch.num_meta += data->at(index).is_meta();
-      current_epoch.has_barrier = true;
-      ++index;
-    }
-    epochs.push_back(current_epoch);
-  }
-}
-
 RandomPermuter::RandomPermuter() {
-  log_length = 0;
   rand = mt19937(42);
 }
 
 RandomPermuter::RandomPermuter(vector<disk_write> *data) {
-  init_data_vector(data);
   // TODO(ashmrtn): Make a flag to make it random or not.
   rand = mt19937(42);
 }
 
-void RandomPermuter::init_data(vector<disk_write> *data) {
-  init_data_vector(data);
+void RandomPermuter::init_data(vector<epoch> *data) {
 }
 
-bool RandomPermuter::gen_one_state(vector<disk_write>& res) {
-  vector<unsigned int> permuted_epoch(0);
-  do {
-    unsigned int total_elements = 0;
-    // Find how many elements we will be returning (randomly determined).
-    uniform_int_distribution<unsigned int> permute_epochs(1, epochs.size());
-    unsigned int num_epochs = permute_epochs(rand);
-    // Don't subtract 1 from this size so that we can send a complete epoch if we
-    // want.
-    uniform_int_distribution<unsigned int> permute_requests(1,
-        epochs.at(num_epochs - 1).length);
-    unsigned int num_requests = permute_requests(rand);
-    for (unsigned int i = 0; i < num_epochs - 1; ++i) {
-      total_elements += epochs.at(i).length;
-    }
-    total_elements += num_requests;
-    res.resize(total_elements);
-    // Add all of the elements as some of the epochs could have been reordered
-    // if they overlapped.
-    permuted_epoch.resize(total_elements);
+bool RandomPermuter::gen_one_state(vector<epoch_op>& res) {
+  unsigned int total_elements = 0;
+  // Find how many elements we will be returning (randomly determined).
+  uniform_int_distribution<unsigned int> permute_epochs(1, GetEpochs()->size());
+  unsigned int num_epochs = permute_epochs(rand);
+  // Don't subtract 1 from this size so that we can send a complete epoch if we
+  // want.
+  uniform_int_distribution<unsigned int> permute_requests(1,
+      GetEpochs()->at(num_epochs - 1).ops.size());
+  unsigned int num_requests = permute_requests(rand);
+  for (unsigned int i = 0; i < num_epochs - 1; ++i) {
+    total_elements += GetEpochs()->at(i).ops.size();
+  }
+  total_elements += num_requests;
+  res.resize(total_elements);
 
-    auto curr_iter = res.begin();
-    auto permute_iter = permuted_epoch.begin();
-    for (unsigned int i = 0; i < num_epochs; ++i) {
-      if (epochs.at(i).overlaps || i == num_epochs - 1) {
-        unsigned int size =
-          (i != num_epochs - 1) ? epochs.at(i).length : num_requests;
-        auto res_end = curr_iter + size;
-        permute_epoch(curr_iter, res_end, permute_iter, epochs.at(i));
+  auto curr_iter = res.begin();
+  for (unsigned int i = 0; i < num_epochs; ++i) {
+    if (GetEpochs()->at(i).overlaps || i == num_epochs - 1) {
+      unsigned int size =
+        (i != num_epochs - 1) ? GetEpochs()->at(i).ops.size() : num_requests;
+      auto res_end = curr_iter + size;
+      permute_epoch(curr_iter, res_end, GetEpochs()->at(i));
 
-        curr_iter = res_end;
-        advance(permute_iter, size);
-      } else {
-        // Use a for loop since vector::insert inserts new elements and we
-        // resized above to the exact size we will have.
-        // We will only ever be placing the full epoch here because the above if
-        // will catch the case where we place only part of an epoch.
-        for (auto epoch_iter = epochs.at(i).ops.begin();
-            epoch_iter != epochs.at(i).ops.end(); ++epoch_iter) {
-          *curr_iter = epoch_iter->op;
-          ++curr_iter;
-          *permute_iter = epoch_iter->abs_index;
-          ++permute_iter;
-        }
+      curr_iter = res_end;
+    } else {
+      // Use a for loop since vector::insert inserts new elements and we
+      // resized above to the exact size we will have.
+      // We will only ever be placing the full epoch here because the above if
+      // will catch the case where we place only part of an epoch.
+      for (auto epoch_iter = GetEpochs()->at(i).ops.begin();
+          epoch_iter != GetEpochs()->at(i).ops.end(); ++epoch_iter) {
+        *curr_iter = *epoch_iter;
+        ++curr_iter;
       }
     }
-  } while (completed_permutations.count(permuted_epoch));
-  completed_permutations.insert(permuted_epoch);
-
+  }
   return true;
 }
 
 void RandomPermuter::permute_epoch(
-      vector<disk_write>::iterator& res_start,
-      vector<disk_write>::iterator& res_end,
-      vector<unsigned int>::iterator& order_start,
+      vector<epoch_op>::iterator& res_start,
+      vector<epoch_op>::iterator& res_end,
       epoch& epoch) {
-  assert(distance(res_start, res_end) <= epoch.length);
+  assert(distance(res_start, res_end) <= epoch.ops.size());
 
   // Even if the number of bios we're placing is less than the number in the
   // epoch, allow any bio but the barrier (if present) to be picked.
-  unsigned int slots = (epoch.has_barrier) ? epoch.length - 1 : epoch.length;
+  unsigned int slots = epoch.ops.size();
+  if (epoch.has_barrier) {
+    --slots;
+  }
 
-  // Fill the list with the empty slots, either [0, epoch.length - 1] or
-  // [0, epoch.length - 2]. Prefer a list so that removals are fast. We have
+  // Fill the list with the empty slots, either [0, epoch.size() - 1] or
+  // [0, epoch.size() - 2]. Prefer a list so that removals are fast. We have
   // this so that each time we pick a number we can find a bio which we haven't
   // already placed.
   list<unsigned int> empty_slots(slots);
@@ -182,10 +99,8 @@ void RandomPermuter::permute_epoch(
     uniform_int_distribution<unsigned int> uid(0, empty_slots.size() - 1);
     auto shift = empty_slots.begin();
     advance(shift, uid(rand));
-    *res_start = epoch.ops.at(*shift).op;
+    *res_start = epoch.ops.at(*shift);
     ++res_start;
-    *order_start = epoch.ops.at(*shift).abs_index;
-    ++order_start;
     empty_slots.erase(shift);
   }
 
@@ -199,8 +114,7 @@ void RandomPermuter::permute_epoch(
   // Place the barrier operation if it exists since the entire vector already
   // exists (i.e. we won't cause extra shifting when adding the other elements).
   // Decrement out count of empty slots since we have filled one.
-  *res_start = epoch.ops.back().op;
-  *order_start = epoch.ops.back().abs_index;
+  *res_start = epoch.ops.back();
 }
 
 }  // namespace permuter

--- a/code/permuter/RandomPermuter.h
+++ b/code/permuter/RandomPermuter.h
@@ -2,7 +2,6 @@
 #define RANDOM_PERMUTER_H
 
 #include <random>
-#include <unordered_set>
 #include <vector>
 
 #include "Permuter.h"

--- a/code/permuter/RandomPermuter.h
+++ b/code/permuter/RandomPermuter.h
@@ -11,63 +11,19 @@
 namespace fs_testing {
 namespace permuter {
 
-struct BioVectorHash {
-  std::size_t operator() (const std::vector<unsigned int>& permutation) const {
-    unsigned int seed = permutation.size();
-    for (const auto& bio_pos : permutation) {
-      seed ^= bio_pos + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    }
-    return seed;
-  }
-};
-
-struct BioVectorEqual {
-  bool operator() (const std::vector<unsigned int>& a,
-      const std::vector<unsigned int>& b) const {
-    if (a.size() != b.size()) {
-      return false;
-    }
-    for (unsigned int i = 0; i < a.size(); ++i) {
-      if (a.at(i) != b.at(i)) {
-        return false;
-      }
-    }
-    return true;
-  }
-};
-
-struct epoch_op {
-  unsigned int abs_index;
-  fs_testing::utils::disk_write op;
-};
-
-struct epoch {
-  unsigned int length;
-  unsigned int num_meta;
-  bool has_barrier;
-  bool overlaps;
-  std::vector<struct epoch_op> ops;
-};
-
 class RandomPermuter : public Permuter {
  public:
   RandomPermuter();
   RandomPermuter(std::vector<fs_testing::utils::disk_write> *data);
-  virtual void init_data(std::vector<fs_testing::utils::disk_write> *data);
-  virtual bool gen_one_state(std::vector<fs_testing::utils::disk_write>& res);
 
  private:
-  void init_data_vector(std::vector<fs_testing::utils::disk_write> *data);
+  virtual void init_data(std::vector<epoch> *data);
+  virtual bool gen_one_state(std::vector<epoch_op>& res);
   void permute_epoch(
-      std::vector<fs_testing::utils::disk_write>::iterator& res_start,
-      std::vector<fs_testing::utils::disk_write>::iterator& res_end,
-      std::vector<unsigned int>::iterator& order_start,
-      epoch& epoch);
-  unsigned int log_length;
-  std::vector<struct epoch> epochs;
+      std::vector<epoch_op>::iterator& res_start,
+      std::vector<epoch_op>::iterator& res_end, epoch& epoch);
+
   std::mt19937 rand;
-  std::unordered_set<std::vector<unsigned int>, BioVectorHash, BioVectorEqual>
-    completed_permutations;
 };
 
 }  // namespace permuter


### PR DESCRIPTION
Per #18, stop testing if no new unique states are found. Tests will exit if the harness must retry X number of times without finding a new unique state. This is a somewhat inefficient failsafe, but at least the harness won't hang looking for new unique states.