### PR TITLE
Allow User Data Consistency Test to Output Meaningful Errors--Closes Issue #17

### DIFF
--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -804,9 +804,9 @@ int Tester::log_snapshot_load(string log_file) {
   return SUCCESS;
 }
 
-void Tester::PrintTestStats(std::ostream& os) {
+void Tester::PrintTestStats(std::ostream& os, bool is_log) {
   for (const auto& suite : test_results_) {
-    suite.PrintResults(os);
+    suite.PrintResults(os, is_log);
   }
 }
 

--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -111,7 +111,7 @@ class Tester {
 
   std::chrono::milliseconds get_timing_stat(time_stats timing_stat);
   void PrintTimingStats(std::ostream& os);
-  void PrintTestStats(std::ostream& os);
+  void PrintTestStats(std::ostream& os, bool is_log);
 
   // TODO(ashmrtn): Figure out why making these private slows things down a lot.
  private:

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -8,8 +8,8 @@
 #include <wait.h>
 
 #include <ctime>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -138,7 +138,8 @@ int main(int argc, char** argv) {
    * 4. load static objects for permuter and test case
    ****************************************************************************/
   const unsigned int test_case_idx = optind;
-
+  const string path = argv[test_case_idx];
+   
   cout << "========== PHASE 0: Setting up CrashMonkey basics =========="
     << endl;
   if (test_case_idx == argc) {
@@ -680,15 +681,13 @@ int main(int argc, char** argv) {
         << endl;
     }
     //get the name of the test being run 
-    string path = argv[test_case_idx];
     int begin = path.rfind('/');
     //remove everything before the last /
-    string test_name = path.substr(begin +1);
+    string test_name = path.substr(begin + 1);
     //remove the extension 
-    test_name = test_name.substr(0, test_name.length()-3); 
+    test_name = test_name.substr(0, test_name.length() - 3); 
     //get the date and time stamp and format
     time_t now = time(0); 
-    char* time = ctime(&now);
     char time_st[18];
     strftime(time_st, sizeof(time_st), "%Y%m%d_%H:%M:%S", localtime(&now));  
     string s = string(time_st) + "-" + test_name + ".log";

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -673,7 +673,7 @@ int main(int argc, char** argv) {
     test_harness.test_check_random_permutations(iterations);
     test_harness.remove_cow_brd();
 
-    test_harness.PrintTestStats(cout);
+    test_harness.PrintTestStats(cout, false);
     cout << endl;
 
     for (unsigned int i = 0; i < Tester::NUM_TIME; ++i) {
@@ -695,7 +695,7 @@ int main(int argc, char** argv) {
     strftime(time_st, sizeof(time_st), "%Y%m%d_%H:%M:%S", localtime(&now));  
     string s = string(time_st) + "-" + test_name + ".log";
     std::ofstream logfile (s);
-    test_harness.PrintTestStats(logfile);
+    test_harness.PrintTestStats(logfile, true);
     logfile.close();
   }
 

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -234,9 +234,7 @@ int main(int argc, char** argv) {
     test_harness.cleanup_harness();
       return -1;
   }
-  //cout << "what is the test???" << endl;
-  //cout << argv[test_case_idx] << endl;
-
+  
   // Load the permuter to use for the test.
   // TODO(ashmrtn): Consider making a line in the test file which specifies the
   // permuter to use?

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -7,7 +7,9 @@
 #include <unistd.h>
 #include <wait.h>
 
+#include <ctime>
 #include <iostream>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -37,6 +39,7 @@ using std::cerr;
 using std::cout;
 using std::endl;
 using std::string;
+using std::to_string;
 using fs_testing::Tester;
 using fs_testing::utils::communication::kSocketNameOutbound;
 using fs_testing::utils::communication::ServerSocket;
@@ -232,6 +235,8 @@ int main(int argc, char** argv) {
     test_harness.cleanup_harness();
       return -1;
   }
+  //cout << "what is the test???" << endl;
+  //cout << argv[test_case_idx] << endl;
 
   // Load the permuter to use for the test.
   // TODO(ashmrtn): Consider making a line in the test file which specifies the
@@ -677,6 +682,18 @@ int main(int argc, char** argv) {
         << test_harness.get_timing_stat((Tester::time_stats) i).count() << " ms"
         << endl;
     }
+    time_t now = time(0);
+    tm *time_stmp = localtime(&now);
+    string time_log = to_string(time_stmp->tm_hour) + ":"
+    + to_string(time_stmp->tm_min) + ":" 
+    + to_string(time_stmp->tm_sec);
+    string date_log = to_string(time_stmp->tm_year) +
+    to_string(time_stmp->tm_mon) + 
+    to_string(time_stmp->tm_mday);
+    string s = time_log + "_" + date_log  +  ".log";
+    std::ofstream logfile (s);
+    test_harness.PrintTestStats(logfile);
+    logfile.close();
   }
 
   cout << endl << "========== PHASE 4: Cleaning up ==========" << endl;

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -157,7 +157,6 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-
   // Create a socket to coordinate with the outside world.
   if (background) {
     // TODO(ashmrtn): Fix permissions on the socket.
@@ -682,15 +681,19 @@ int main(int argc, char** argv) {
         << test_harness.get_timing_stat((Tester::time_stats) i).count() << " ms"
         << endl;
     }
-    time_t now = time(0);
-    tm *time_stmp = localtime(&now);
-    string time_log = to_string(time_stmp->tm_hour) + ":"
-    + to_string(time_stmp->tm_min) + ":" 
-    + to_string(time_stmp->tm_sec);
-    string date_log = to_string(time_stmp->tm_year) +
-    to_string(time_stmp->tm_mon) + 
-    to_string(time_stmp->tm_mday);
-    string s = time_log + "_" + date_log  +  ".log";
+    //get the name of the test being run 
+    string path = argv[test_case_idx];
+    int begin = path.rfind('/');
+    //remove everything before the last /
+    string test_name = path.substr(begin +1);
+    //remove the extension 
+    test_name = test_name.substr(0, test_name.length()-3); 
+    //get the date and time stamp and format
+    time_t now = time(0); 
+    char* time = ctime(&now);
+    char time_st[18];
+    strftime(time_st, sizeof(time_st), "%Y%m%d_%H:%M:%S", localtime(&now));  
+    string s = string(time_st) + "-" + test_name + ".log";
     std::ofstream logfile (s);
     test_harness.PrintTestStats(logfile);
     logfile.close();

--- a/code/results/TestSuiteResult.cpp
+++ b/code/results/TestSuiteResult.cpp
@@ -64,7 +64,7 @@ void TestSuiteResult::PrintResults(ostream& os) const {
           break;
 	//os << ": " << result.data_test.error_description << "\n";
       }
-      os << "Test #" << num_failed << " FAILED: "<< des << result.data_test.error_description <<"\n";
+      //os << "Test #" << num_failed << " FAILED: "<< des << result.data_test.error_description <<"\n";
     }
   }
 

--- a/code/results/TestSuiteResult.cpp
+++ b/code/results/TestSuiteResult.cpp
@@ -24,6 +24,7 @@ void TestSuiteResult::PrintResults(ostream& os, bool is_log) const {
   unsigned int num_failed = 0;
   unsigned int num_passed_fixed = 0;
   unsigned int num_passed = 0;
+  unsigned int total_tests = 0;
 
   unsigned int old_file_persisted = 0;
   unsigned int file_missing = 0;
@@ -32,6 +33,7 @@ void TestSuiteResult::PrintResults(ostream& os, bool is_log) const {
   unsigned int other = 0;
 
   for (const auto& result : completed_) {
+    total_tests++;
     if (result.fs_test.GetError() == FileSystemTestResult::kClean
         && result.data_test.GetError() == DataTestResult::kClean) {
       ++num_passed;
@@ -63,8 +65,9 @@ void TestSuiteResult::PrintResults(ostream& os, bool is_log) const {
           ++other;
           break;
       }
-      if(is_log)
-          os << "Test #" << num_failed << " FAILED: "<< des << result.data_test.error_description <<"\n";
+      if(is_log){
+          os << "Test #" << total_tests << " FAILED: " << des << result.data_test.error_description << "\n";
+      }
     }
   }
 

--- a/code/results/TestSuiteResult.cpp
+++ b/code/results/TestSuiteResult.cpp
@@ -20,7 +20,7 @@ unsigned int TestSuiteResult::GetCompleted() const {
   return completed_.size();
 }
 
-void TestSuiteResult::PrintResults(ostream& os) const {
+void TestSuiteResult::PrintResults(ostream& os, bool is_log) const {
   unsigned int num_failed = 0;
   unsigned int num_passed_fixed = 0;
   unsigned int num_passed = 0;
@@ -62,9 +62,9 @@ void TestSuiteResult::PrintResults(ostream& os) const {
           des += "other: ";
           ++other;
           break;
-	//os << ": " << result.data_test.error_description << "\n";
       }
-      //os << "Test #" << num_failed << " FAILED: "<< des << result.data_test.error_description <<"\n";
+      if(is_log)
+          os << "Test #" << num_failed << " FAILED: "<< des << result.data_test.error_description <<"\n";
     }
   }
 

--- a/code/results/TestSuiteResult.cpp
+++ b/code/results/TestSuiteResult.cpp
@@ -40,23 +40,31 @@ void TestSuiteResult::PrintResults(ostream& os) const {
       ++num_passed_fixed;
     } else {
       ++num_failed;
+      std::string des(""); 
       switch (result.data_test.GetError()) {
         case DataTestResult::kOldFilePersisted:
+          des += "old file persisted: ";
           ++old_file_persisted;
           break;
         case DataTestResult::kFileMissing:
+          des += "file missing: ";
           ++file_missing;
           break;
         case DataTestResult::kFileDataCorrupted:
+          des += "file data corrupted: ";
           ++file_data_corrupted;
           break;
         case DataTestResult::kFileMetadataCorrupted:
+          des += "file metadata corrupted: ";
           ++file_metadata_corrupted;
           break;
         case DataTestResult::kOther:
+          des += "other: ";
           ++other;
           break;
+	//os << ": " << result.data_test.error_description << "\n";
       }
+      os << "Test #" << num_failed << " FAILED: "<< des << result.data_test.error_description <<"\n";
     }
   }
 

--- a/code/results/TestSuiteResult.h
+++ b/code/results/TestSuiteResult.h
@@ -13,7 +13,7 @@ class TestSuiteResult {
  public:
   void AddCompletedTest(const fs_testing::SingleTestInfo& done);
   unsigned int GetCompleted() const;
-  void PrintResults(std::ostream& os) const;
+  void PrintResults(std::ostream& os, bool is_log) const;
 
  private:
   std::vector<fs_testing::SingleTestInfo> completed_;


### PR DESCRIPTION
Hi guys! Here's my pull request--sorry it took so long (I'm a little fuzzy with git). 
There  are some things I have done in here that may need adjustment:
1. I didn't want it to print the detailed test results every time you run the program. I simply wanted to put them in the log file. Right now I am passing a boolean flag to let TestSuiteResult know if the outstream is the log file. If there's a better way of doing this please let me know. Also, if we'd like to add an option for the user to decide whether they want a log file and what they want printed to it, let me know. 
2. If there is no user description to be added to the test failure description, then that section is left blank and would look like: 
test #1 FAILED file_missing:
as opposed to 
test #1 FAILED file_missing: mnt/snapshot/test_dir/test_file is missing
Also I only supply the description if the test failed, otherwise there is no output. 

I am new to c++, so please let me know if there is a better or more efficient way of doing something. 

Thank you and please let me know if you have any questions :) 

Sonika 