### PR TITLE
Update RandomPermuter.cpp

### DIFF
--- a/code/permuter/RandomPermuter.cpp
+++ b/code/permuter/RandomPermuter.cpp
@@ -46,6 +46,8 @@ bool RandomPermuter::gen_one_state(vector<epoch_op>& res,
   uniform_int_distribution<unsigned int> permute_requests(1,
       GetEpochs()->at(num_epochs - 1).ops.size());
   unsigned int num_requests = permute_requests(rand);
+  // If the last epoch has zero ops, we set num_requests to zero instead of a 
+  // garbage value returned by permute_requests(rand)
   if (GetEpochs()->at(num_epochs - 1).ops.size() == 0) {
     num_requests = 0;
   }

--- a/code/permuter/RandomPermuter.cpp
+++ b/code/permuter/RandomPermuter.cpp
@@ -46,6 +46,9 @@ bool RandomPermuter::gen_one_state(vector<epoch_op>& res,
   uniform_int_distribution<unsigned int> permute_requests(1,
       GetEpochs()->at(num_epochs - 1).ops.size());
   unsigned int num_requests = permute_requests(rand);
+  if (GetEpochs()->at(num_epochs - 1).ops.size() == 0) {
+    num_requests = 0;
+  }
   for (unsigned int i = 0; i < num_epochs - 1; ++i) {
     total_elements += GetEpochs()->at(i).ops.size();
   }


### PR DESCRIPTION
Fixing the BadAlloc() exception that arises due to num_requests being assigned a garbage value when the last epoch has zero ops!