### PR TITLE
My code for Issue #9--Sets environment variables for mount directory/filesystem size and passes those variables to tests. 

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -11,7 +11,12 @@ MODULES = cow_brd disk_wrapper
 obj-m := $(addsuffix .o, $(MODULES))
 KDIR := /lib/modules/$(shell uname -r)/build
 
+CM_TESTS_EXCLUDE = BaseTestCase.cpp
 CM_TESTS = $(patsubst %.cpp, %.so, $(notdir $(wildcard $(CURDIR)/tests/*.cpp)))
+CM_TESTS = \
+		$(patsubst %.cpp, %.so, \
+			$(filter-out $(CM_TESTS_EXCLUDE), \
+				$(notdir $(wildcard $(CURDIR)/tests/*.cpp))))
 CM_PERMUTER_EXCLUDE = Permuter.cpp
 CM_PERMUTERS = \
 		$(patsubst %.cpp, %.so, \
@@ -87,6 +92,7 @@ $(BUILD_DIR)/c_harness: \
 
 $(BUILD_DIR)/tests/%.so: \
 		tests/%.cpp \
+		$(BUILD_DIR)/tests/BaseTestCase.o \
 		$(BUILD_DIR)/user_tools/src/actions.o \
 		$(BUILD_DIR)/utils/communication/BaseSocket.o \
 		$(BUILD_DIR)/utils/communication/ClientSocket.o \

--- a/code/Makefile
+++ b/code/Makefile
@@ -12,7 +12,6 @@ obj-m := $(addsuffix .o, $(MODULES))
 KDIR := /lib/modules/$(shell uname -r)/build
 
 CM_TESTS_EXCLUDE = BaseTestCase.cpp
-CM_TESTS = $(patsubst %.cpp, %.so, $(notdir $(wildcard $(CURDIR)/tests/*.cpp)))
 CM_TESTS = \
 		$(patsubst %.cpp, %.so, \
 			$(filter-out $(CM_TESTS_EXCLUDE), \

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -451,7 +451,7 @@ int Tester::test_setup() {
   return test_loader.get_instance()->setup();
 }
 
-int Tester::test_init_values(string mount_dir, long filesys_size){
+int Tester::test_init_values(string mount_dir, long filesys_size) {
   return test_loader.get_instance()->init_values(mount_dir, filesys_size);
 }
 

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -450,6 +450,10 @@ int Tester::test_setup() {
   return test_loader.get_instance()->setup();
 }
 
+int Tester::test_pass(string mountDir, string filesysSize){
+  return test_loader.get_instance()->pass(mountDir, filesysSize);
+}
+
 int Tester::test_run() {
   return test_loader.get_instance()->run();
 }

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -450,8 +450,8 @@ int Tester::test_setup() {
   return test_loader.get_instance()->setup();
 }
 
-int Tester::test_pass(string mountDir, string filesysSize){
-  return test_loader.get_instance()->pass(mountDir, filesysSize);
+int Tester::test_pass(string mount_dir, string filesys_size){
+  return test_loader.get_instance()->pass(mount_dir, filesys_size);
 }
 
 int Tester::test_run() {

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -450,8 +450,8 @@ int Tester::test_setup() {
   return test_loader.get_instance()->setup();
 }
 
-int Tester::test_pass(string mount_dir, string filesys_size){
-  return test_loader.get_instance()->pass(mount_dir, filesys_size);
+int Tester::test_init_values(string mount_dir, long filesys_size){
+  return test_loader.get_instance()->init_values(mount_dir, filesys_size);
 }
 
 int Tester::test_run() {

--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -78,6 +78,7 @@ class Tester {
   int test_load_class(const char* path);
   void test_unload_class();
   int test_setup();
+  int test_pass(std::string mountDir, std::string filesysSize);
   int test_run();
   int test_check_permutations(const int num_rounds);
   int test_check_random_permutations(const int num_rounds);

--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -78,7 +78,7 @@ class Tester {
   int test_load_class(const char* path);
   void test_unload_class();
   int test_setup();
-  int test_pass(std::string mountDir, std::string filesysSize);
+  int test_init_values(std::string mountDir, long filesysSize);
   int test_run();
   int test_check_permutations(const int num_rounds);
   int test_check_random_permutations(const int num_rounds);

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -146,6 +146,7 @@ int main(int argc, char** argv) {
   std::getline(infile,line);
   cout << line << endl;
   setenv("FILESYS_SIZE", line.c_str(), 1);
+  remove("filesize.txt");
   cout << "========== PHASE 0: Setting up CrashMonkey basics =========="
     << endl;
   if (test_case_idx == argc) {

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -45,6 +45,7 @@ using fs_testing::utils::communication::kSocketNameOutbound;
 using fs_testing::utils::communication::ServerSocket;
 using fs_testing::utils::communication::SocketError;
 using fs_testing::utils::communication::SocketMessage;
+
 static const option long_options[] = {
   {"background", no_argument, NULL, 'b'},
   {"test-dev", required_argument, NULL, 'd'},
@@ -144,32 +145,6 @@ int main(int argc, char** argv) {
     cerr << "Error setting environment variable MOUNT_FS" << endl;
   }
   
-  //input file created to read output from bash command "df"
-  /*FILE *input;
-  char buf[512];
-  if(!(input = popen(("fdisk -l | grep " + flags_dev + ": ").c_str(), "r"))){
-    cerr << "Error finding the filesize of mounted filesystem" << endl;  
-  }
-  string filesize;
-  while(fgets(buf, 512, input)){
-    filesize += buf;
-  }
-  pclose(input);
-  char * tok = strtok(filesize, " ");
-  int pos = 0;
-  while (pos < 3 && tok != NULL){
-    pos ++;
-    tok = strtok(filesize, " ");
-   }
-   if(tok != NULL){
-     long test_dev_size = atoi(tok);
-   }
-   /*cout << test_dev_size << endl;
-
-  //cout << filesize << endl;
-  if(setenv("FILESYS_SIZE", filesize.c_str(), 1) == -1){
-    cerr << "Error setting environment variable FILESYS_SIZE" << endl;
-  }
   cout << "========== PHASE 0: Setting up CrashMonkey basics =========="
     << endl;
   if (test_case_idx == argc) {

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -139,14 +139,28 @@ int main(int argc, char** argv) {
    ****************************************************************************/
   const unsigned int test_case_idx = optind;
   const string path = argv[test_case_idx];
-  setenv("MOUNT_FS", test_dev.c_str(), 1);
-  int i = system(("df --output=source,size | grep "+flags_dev + "> filesize.txt").c_str());
-  std::ifstream infile("filesize.txt");
-  string line;
-  std::getline(infile,line);
-  cout << line << endl;
-  setenv("FILESYS_SIZE", line.c_str(), 1);
-  remove("filesize.txt");
+  int errno = setenv("MOUNT_FS", test_dev.c_str(), 1);
+  if (errno < 0){
+    cerr << "Error Setting environment variable MOUNT_FS" << errno << endl;
+  }
+  int errno = system(("df --output=source,size | grep "+flags_dev + "> filesize.txt").c_str());
+  if ( errno < 0){
+    cerr << "Error finding the filesize of mounted filesystem" << errno << endl;
+  }
+  else{
+     std::ifstream infile("filesize.txt");
+     string line;
+     std::getline(infile,line);
+     cout << line << endl;
+     int errno = setenv("FILESYS_SIZE", line.c_str(), 1);
+     if (errno < 0){
+       cerr << "Error setting environment variable FILESYS_SIZE" << errno << endl;
+     }
+     int errno = remove("filesize.txt");
+     if (errno < 0){
+       cerr << "Error removing residual file--filesize.txt" << erro << endl;
+     } 
+  }
   cout << "========== PHASE 0: Setting up CrashMonkey basics =========="
     << endl;
   if (test_case_idx == argc) {

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -260,13 +260,12 @@ int main(int argc, char** argv) {
   while (pos < 4 && tok != NULL){
     pos ++;
     tok = strtok(NULL, " ");
-   }
-   long test_dev_size = 0;
-   if(tok != NULL){
-     test_dev_size = atol(tok);
-   }
-   //cout << test_dev_size << endl;
-   delete [] filesize_cstr;
+  }
+  long test_dev_size = 0;
+  if(tok != NULL){
+    test_dev_size = atol(tok);
+  }
+  delete [] filesize_cstr;
   if(setenv("FILESYS_SIZE", filesize.c_str(), 1) == -1){
     cerr << "Error setting environment variable FILESYS_SIZE" << endl;
   }

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -138,6 +138,7 @@ int main(int argc, char** argv) {
    ****************************************************************************/
   const unsigned int test_case_idx = optind;
   const string path = argv[test_case_idx];
+  cout << test_dev << endl;
   if(!(setenv("MOUNT_FS", test_dev.c_str(), 1))){
     cerr << "Error setting environment variable MOUNT_FS" << endl;
   }
@@ -228,7 +229,7 @@ int main(int argc, char** argv) {
   }
   test_harness.set_fs_type(fs_type);
   test_harness.set_device(test_dev);
-
+  test_harness.test_pass(test_dev, filesize);
   // Load the class being tested.
   cout << "Loading test case" << endl;
   if (test_harness.test_load_class(argv[test_case_idx]) != SUCCESS) {

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -139,7 +139,13 @@ int main(int argc, char** argv) {
    ****************************************************************************/
   const unsigned int test_case_idx = optind;
   const string path = argv[test_case_idx];
-   
+  setenv("MOUNT_FS", test_dev.c_str(), 1);
+  int i = system(("df --output=source,size | grep "+flags_dev + "> filesize.txt").c_str());
+  std::ifstream infile("filesize.txt");
+  string line;
+  std::getline(infile,line);
+  cout << line << endl;
+  setenv("FILESYS_SIZE", line.c_str(), 1);
   cout << "========== PHASE 0: Setting up CrashMonkey basics =========="
     << endl;
   if (test_case_idx == argc) {

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -45,7 +45,6 @@ using fs_testing::utils::communication::kSocketNameOutbound;
 using fs_testing::utils::communication::ServerSocket;
 using fs_testing::utils::communication::SocketError;
 using fs_testing::utils::communication::SocketMessage;
-
 static const option long_options[] = {
   {"background", no_argument, NULL, 'b'},
   {"test-dev", required_argument, NULL, 'd'},
@@ -139,22 +138,22 @@ int main(int argc, char** argv) {
    ****************************************************************************/
   const unsigned int test_case_idx = optind;
   const string path = argv[test_case_idx];
-  int errno = setenv("MOUNT_FS", test_dev.c_str(), 1);
-  if (errno < 0){
-    cerr << "Error Setting environment variable MOUNT_FS" << errno << endl;
+  if(!(setenv("MOUNT_FS", test_dev.c_str(), 1))){
+    cerr << "Error setting environment variable MOUNT_FS" << endl;
   }
   FILE *input;
   char buf[512];
-  if(!(input = popen(("df --output=source,size | grep " + flags_dev + ">filesize.txt").c_str()){
+  if(!(input = popen(("df --output=source,size | grep " + flags_dev).c_str(), "r"))){
     cerr << "Error finding the filesize of mounted filesystem" << endl;  
   }
   string filesize;
-  while(fgets(buf, 512, input){
+  while(fgets(buf, 512, input)){
     filesize += buf;
   }
-  int errno = setenv("FILESYS_SIZE", filesize.c_str(), 1);
-  if (errno < 0){
-    cerr << "Error setting environment variable FILESYS_SIZE" << errno << endl;
+  //fileSysSize = filesize;
+  pclose(input);
+  if(!setenv("FILESYS_SIZE", filesize.c_str(), 1)){
+    cerr << "Error setting environment variable FILESYS_SIZE" << endl;
   }
   cout << "========== PHASE 0: Setting up CrashMonkey basics =========="
     << endl;

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -145,9 +145,9 @@ int main(int argc, char** argv) {
   }
   
   //input file created to read output from bash command "df"
-  FILE *input;
+  /*FILE *input;
   char buf[512];
-  if(!(input = popen(("df --output=source,size | grep " + flags_dev).c_str(), "r"))){
+  if(!(input = popen(("fdisk -l | grep " + flags_dev + ": ").c_str(), "r"))){
     cerr << "Error finding the filesize of mounted filesystem" << endl;  
   }
   string filesize;
@@ -155,7 +155,18 @@ int main(int argc, char** argv) {
     filesize += buf;
   }
   pclose(input);
+  char * tok = strtok(filesize, " ");
+  int pos = 0;
+  while (pos < 3 && tok != NULL){
+    pos ++;
+    tok = strtok(filesize, " ");
+   }
+   if(tok != NULL){
+     long test_dev_size = atoi(tok);
+   }
+   /*cout << test_dev_size << endl;
 
+  //cout << filesize << endl;
   if(setenv("FILESYS_SIZE", filesize.c_str(), 1) == -1){
     cerr << "Error setting environment variable FILESYS_SIZE" << endl;
   }
@@ -232,6 +243,33 @@ int main(int argc, char** argv) {
   }
   test_harness.set_fs_type(fs_type);
   test_harness.set_device(test_dev);
+  FILE *input;
+  char buf[512];
+  if(!(input = popen(("fdisk -l " + test_dev + " | grep " + test_dev + ": ").c_str(), "r"))){
+    cerr << "Error finding the filesize of mounted filesystem" << endl;  
+  }
+  string filesize;
+  while(fgets(buf, 512, input)){
+    filesize += buf;
+  }
+  pclose(input);
+  char *filesize_cstr = new char[filesize.length() + 1];
+  strcpy(filesize_cstr, filesize.c_str()); 
+  char * tok = strtok(filesize_cstr, " ");
+  int pos = 0;
+  while (pos < 4 && tok != NULL){
+    pos ++;
+    tok = strtok(NULL, " ");
+   }
+   long test_dev_size = 0;
+   if(tok != NULL){
+     test_dev_size = atol(tok);
+   }
+   //cout << test_dev_size << endl;
+   delete [] filesize_cstr;
+  if(setenv("FILESYS_SIZE", filesize.c_str(), 1) == -1){
+    cerr << "Error setting environment variable FILESYS_SIZE" << endl;
+  }
   
   // Load the class being tested.
   cout << "Loading test case" << endl;
@@ -240,7 +278,7 @@ int main(int argc, char** argv) {
       return -1;
   }
   
-  test_harness.test_pass(mount_dir, filesize);
+  test_harness.test_init_values(mount_dir, test_dev_size);
   
   // Load the permuter to use for the test.
   // TODO(ashmrtn): Consider making a line in the test file which specifies the

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -143,23 +143,18 @@ int main(int argc, char** argv) {
   if (errno < 0){
     cerr << "Error Setting environment variable MOUNT_FS" << errno << endl;
   }
-  int errno = system(("df --output=source,size | grep "+flags_dev + "> filesize.txt").c_str());
-  if ( errno < 0){
-    cerr << "Error finding the filesize of mounted filesystem" << errno << endl;
+  FILE *input;
+  char buf[512];
+  if(!(input = popen(("df --output=source,size | grep " + flags_dev + ">filesize.txt").c_str()){
+    cerr << "Error finding the filesize of mounted filesystem" << endl;  
   }
-  else{
-     std::ifstream infile("filesize.txt");
-     string line;
-     std::getline(infile,line);
-     cout << line << endl;
-     int errno = setenv("FILESYS_SIZE", line.c_str(), 1);
-     if (errno < 0){
-       cerr << "Error setting environment variable FILESYS_SIZE" << errno << endl;
-     }
-     int errno = remove("filesize.txt");
-     if (errno < 0){
-       cerr << "Error removing residual file--filesize.txt" << erro << endl;
-     } 
+  string filesize;
+  while(fgets(buf, 512, input){
+    filesize += buf;
+  }
+  int errno = setenv("FILESYS_SIZE", filesize.c_str(), 1);
+  if (errno < 0){
+    cerr << "Error setting environment variable FILESYS_SIZE" << errno << endl;
   }
   cout << "========== PHASE 0: Setting up CrashMonkey basics =========="
     << endl;

--- a/code/tests/BaseTestCase.cpp
+++ b/code/tests/BaseTestCase.cpp
@@ -5,7 +5,7 @@ namespace tests {
 
 using std::string;
 
-int BaseTestCase::pass(string mount_dir, string filesys_size) {
+int BaseTestCase::init_values(string mount_dir, long filesys_size) {
   mnt_dir_ = mount_dir;
   filesys_size_ = filesys_size;
   return 0;

--- a/code/tests/BaseTestCase.cpp
+++ b/code/tests/BaseTestCase.cpp
@@ -1,0 +1,15 @@
+#include "BaseTestCase.h"
+
+namespace fs_testing {
+namespace tests {
+
+using std::string;
+
+int BaseTestCase::pass(string mount_dir, string filesys_size) {
+  mnt_dir_ = mount_dir;
+  filesys_size_ = filesys_size;
+  return 0;
+}
+
+}  // namespace tests
+}  // namespace fs_testing

--- a/code/tests/BaseTestCase.h
+++ b/code/tests/BaseTestCase.h
@@ -1,5 +1,5 @@
-#ifndef TEST_CASE_H
-#define TEST_CASE_H
+#ifndef BASE_TEST_CASE_H
+#define BASE_TEST_CASE_H
 
 #include "../results/DataTestResult.h"
 #include <string>
@@ -13,11 +13,16 @@ class BaseTestCase {
   virtual int run() = 0;
   virtual int check_test(unsigned int last_checkpoint,
       DataTestResult *test_result) = 0;
-  virtual int pass(std::string mountDir, std::string filesysSize) {}
+  virtual int pass(std::string mount_dir, std::string filesys_size);
+
+ protected:
+  std::string mnt_dir_;
+  std::string filesys_size_;
 };
 
 typedef BaseTestCase *test_create_t();
 typedef void test_destroy_t(BaseTestCase *instance);
+
 }  // namespace tests
 }  // namespace fs_testing
 

--- a/code/tests/BaseTestCase.h
+++ b/code/tests/BaseTestCase.h
@@ -8,13 +8,12 @@ namespace tests {
 
 class BaseTestCase {
  public:
-  std::string mountDir;
-  std::string fileSysSize;
   virtual ~BaseTestCase() {};
   virtual int setup() = 0;
   virtual int run() = 0;
   virtual int check_test(unsigned int last_checkpoint,
       DataTestResult *test_result) = 0;
+  virtual int pass(std::string mountDir, std::string filesysSize) {}
 };
 
 typedef BaseTestCase *test_create_t();

--- a/code/tests/BaseTestCase.h
+++ b/code/tests/BaseTestCase.h
@@ -2,12 +2,14 @@
 #define TEST_CASE_H
 
 #include "../results/DataTestResult.h"
-
+#include <string>
 namespace fs_testing {
 namespace tests {
 
 class BaseTestCase {
  public:
+  std::string mountDir;
+  std::string fileSysSize;
   virtual ~BaseTestCase() {};
   virtual int setup() = 0;
   virtual int run() = 0;
@@ -17,7 +19,6 @@ class BaseTestCase {
 
 typedef BaseTestCase *test_create_t();
 typedef void test_destroy_t(BaseTestCase *instance);
-
 }  // namespace tests
 }  // namespace fs_testing
 

--- a/code/tests/BaseTestCase.h
+++ b/code/tests/BaseTestCase.h
@@ -2,7 +2,9 @@
 #define BASE_TEST_CASE_H
 
 #include "../results/DataTestResult.h"
+
 #include <string>
+
 namespace fs_testing {
 namespace tests {
 
@@ -13,11 +15,11 @@ class BaseTestCase {
   virtual int run() = 0;
   virtual int check_test(unsigned int last_checkpoint,
       DataTestResult *test_result) = 0;
-  virtual int pass(std::string mount_dir, std::string filesys_size);
+  virtual int init_values(std::string mount_dir, long filesys_size);
 
  protected:
   std::string mnt_dir_;
-  std::string filesys_size_;
+  long filesys_size_;
 };
 
 typedef BaseTestCase *test_create_t();

--- a/code/tests/rename_root_to_sub.cpp
+++ b/code/tests/rename_root_to_sub.cpp
@@ -209,6 +209,9 @@ class rename_root_to_sub : public BaseTestCase {
 
     return 0;
   }
+  virtual int pass(std::string mountDir, std::string filesysSize){
+    std::cout << mountDir << " " << filesysSize << std::endl;
+  }
 
  private:
     char text[strlen(TEST_TEXT)];

--- a/code/tests/rename_root_to_sub.cpp
+++ b/code/tests/rename_root_to_sub.cpp
@@ -209,9 +209,6 @@ class rename_root_to_sub : public BaseTestCase {
 
     return 0;
   }
-  virtual int pass(std::string mountDir, std::string filesysSize){
-    std::cout << mountDir << " " << filesysSize << std::endl;
-  }
 
  private:
     char text[strlen(TEST_TEXT)];


### PR DESCRIPTION
Please let me know if any of the assumptions I've made in the code are incorrect. 
I am currently using popen and pclose, which pipes the output of the "df" command into a file and then reads it, to get the file system size. Let me know if there's a better way to handle that. 
Additionally, currently, the mount directory is just hardcoded to /mnt/snapshot. If I need to change this so that the user can pass it in instead, let me know. 
Also, to check that I am actually able to access the variables once they are set, I replaced the constant TEST_MNT with mnt_dir_ and ran a test (rename_root_to_sub). The test ran the same way as before. 
Hopefully this takes care of issue #9 . Let me know if I missed anything. 

Thank you :) 