### PR TITLE
Fix saving disk images to file. Convert to binary dump of logged data.

### DIFF
--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -742,7 +742,7 @@ int Tester::log_profile_save(string log_file) {
 }
 
 int Tester::log_profile_load(string log_file) {
-  ifstream log(log_file);
+  ifstream log(log_file, ios::binary);
   while (log.peek() != EOF) {
     log_data.push_back(disk_write::deserialize(log));
   }

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -777,6 +777,7 @@ int Tester::log_snapshot_save(string log_file) {
   int res = lseek(cow_brd_fd, 0, SEEK_SET);
   if (res < 0) {
     cerr << "error seeking to start of test device" << endl;
+    return LOG_CLONE_ERR;
   }
   while (bytes_done < dev_bytes) {
     // Read a block of data from the base disk image.
@@ -788,7 +789,7 @@ int Tester::log_snapshot_save(string log_file) {
       int res = read(cow_brd_fd, buf + bytes, new_amount - bytes);
       if (res < 0) {
         cerr << "error reading from raw device to log disk snapshot" << endl;
-        break;
+        return LOG_CLONE_ERR;
       }
       bytes += res;
     } while (bytes < new_amount);
@@ -799,7 +800,7 @@ int Tester::log_snapshot_save(string log_file) {
       int res = write(log_fd, buf + bytes, new_amount - bytes);
       if (res < 0) {
         cerr << "error reading from raw device to log disk snapshot" << endl;
-        break;
+        return LOG_CLONE_ERR;
       }
       bytes += res;
     } while (bytes < new_amount);
@@ -817,6 +818,7 @@ int Tester::log_snapshot_load(string log_file) {
   int res = ioctl(cow_brd_fd, COW_BRD_WIPE);
   if (res < 0) {
     cerr << "error wiping old disk snapshot" << endl;
+    return LOG_CLONE_ERR;
   }
 
   // device_size happens to be the number of 1k blocks on cow_brd (from original
@@ -841,10 +843,12 @@ int Tester::log_snapshot_load(string log_file) {
   res = lseek(device_path, 0, SEEK_SET);
   if (res < 0) {
     cerr << "error seeking to start of test device" << endl;
+    return LOG_CLONE_ERR;
   }
   res = lseek(log_fd, 0, SEEK_SET);
   if (res < 0) {
-    cerr << "error seeking to start of test device" << endl;
+    cerr << "error seeking to start of log file" << endl;
+    return LOG_CLONE_ERR;
   }
   while (bytes_done < dev_bytes) {
     // Read a block of data from the base disk image.
@@ -856,7 +860,7 @@ int Tester::log_snapshot_load(string log_file) {
       int res = read(log_fd, buf + bytes, new_amount - bytes);
       if (res < 0) {
         cerr << "error reading from raw device to log disk snapshot" << endl;
-        break;
+        return LOG_CLONE_ERR;
       }
       bytes += res;
     } while (bytes < new_amount);
@@ -867,7 +871,7 @@ int Tester::log_snapshot_load(string log_file) {
       int res = write(device_path, buf + bytes, new_amount - bytes);
       if (res < 0) {
         cerr << "error reading from raw device to log disk snapshot" << endl;
-        break;
+        return LOG_CLONE_ERR;
       }
       bytes += res;
     } while (bytes < new_amount);
@@ -879,6 +883,7 @@ int Tester::log_snapshot_load(string log_file) {
   res = ioctl(cow_brd_fd, COW_BRD_SNAPSHOT);
   if (res < 0) {
     cerr << "error restoring snapshot from log" << endl;
+    return LOG_CLONE_ERR;
   }
   return SUCCESS;
 }

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -76,6 +76,7 @@ using std::cout;
 using std::endl;
 using std::free;
 using std::ifstream;
+using std::ios;
 using std::ostream;
 using std::ofstream;
 using std::shared_ptr;
@@ -732,7 +733,7 @@ int Tester::log_profile_save(string log_file) {
   // class specific one that is set at class creation time. That way people
   // don't break our logging system.
   std::cout << "saving " << log_data.size() << " disk operations" << endl;
-  ofstream log(log_file, std::ofstream::trunc);
+  ofstream log(log_file, std::ofstream::trunc | ios::binary);
   for (const disk_write& dw : log_data) {
     disk_write::serialize(log, dw);
   }

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -761,6 +761,8 @@ int Tester::log_snapshot_save(string log_file) {
   // TODO(ashmrtn): What happens if this fails?
   // TODO(ashmrtn): Change device_clone to be an mmap of the disk we need to get
   // stuff on.
+  // device_size happens to be the number of 1k blocks on cow_brd (from original
+  // brd behavior...), so convert it to a number of bytes.
   unsigned int dev_bytes = device_size * 2 * 512;
   unsigned int bytes_done = 0;
   const unsigned int buf_size = 4096;
@@ -817,6 +819,8 @@ int Tester::log_snapshot_load(string log_file) {
     cerr << "error wiping old disk snapshot" << endl;
   }
 
+  // device_size happens to be the number of 1k blocks on cow_brd (from original
+  // brd behavior...), so convert it to a number of bytes.
   unsigned int dev_bytes = device_size * 2 * 512;
   unsigned int bytes_done = 0;
   const unsigned int buf_size = 4096;

--- a/code/utils/utils.cpp
+++ b/code/utils/utils.cpp
@@ -112,7 +112,7 @@ void disk_write::serialize(std::ofstream& fs, const disk_write& dw) {
   memcpy(buffer + buf_offset, &write_write_sector, 8);
   buf_offset += 8;
   memcpy(buffer + buf_offset, &write_size, 8);
-  buf_offset += 8;
+  
   fs.write(buffer, buf_size);
   if (!fs.good()) {
     std::cerr << "some error writing to file" << std::endl;


### PR DESCRIPTION
This allows developers to easily run `hexdump` or similar on the `_profile` (saved log data) file to see what is happening in it. It also fixes an issue where only a fraction of the total disk was saved when writing the base disk image to a file.