### PR TITLE
Minor updates to data CrashMonkey records and its wait times.

### DIFF
--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -506,6 +506,11 @@ int Tester::test_check_random_permutations(const int num_rounds) {
         duration_cast<milliseconds>(snapshot_end_time - snapshot_start_time);
     // End snapshot timing.
 
+    if (verbose) {
+      std::cout << "Test #" << rounds + 1 << ": Writing " << permutes.size()
+        << " operations to disk" << std::endl;
+    }
+
     // Write recorded data out to block device in different orders so that we
     // can if they are all valid or not.
     time_point<steady_clock> bio_write_start_time = steady_clock::now();

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -19,12 +19,17 @@
 #include "../utils/utils.h"
 #include "Tester.h"
 
+#define STRINGIFY(x) #x
+#define TO_STRING(x) STRINGIFY(x)
+
 #define TEST_SO_PATH "tests/"
 #define PERMUTER_SO_PATH "permuter/"
 // TODO(ashmrtn): Find a good delay time to use for tests.
-#define TEST_DIRTY_EXPIRE_TIME "500"
-#define WRITE_DELAY 20
-#define MOUNT_DELAY 3
+#define TEST_DIRTY_EXPIRE_TIME_CENTISECS 3000
+#define TEST_DIRTY_EXPIRE_TIME_STRING \
+  TO_STRING(TEST_DIRTY_EXPIRE_TIME_CENTISECS)
+#define WRITE_DELAY ((TEST_DIRTY_EXPIRE_TIME_CENTISECS / 100) * 4)
+#define MOUNT_DELAY 1
 
 #define DIRECTORY_PERMS \
   (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
@@ -63,7 +68,9 @@ static const option long_options[] = {
 };
 
 int main(int argc, char** argv) {
-  string dirty_expire_time_centisecs(TEST_DIRTY_EXPIRE_TIME);
+  cout << "running " << argv << endl;
+
+  string dirty_expire_time_centisecs(TEST_DIRTY_EXPIRE_TIME_STRING);
   unsigned long int test_sleep_delay = WRITE_DELAY;
   string fs_type("ext4");
   string flags_dev("/dev/vda");
@@ -231,7 +238,8 @@ int main(int argc, char** argv) {
   }
 
   // Update dirty_expire_time.
-  cout << "Updating dirty_expire_time_centisecs" << endl;
+  cout << "Updating dirty_expire_time_centisecs to "
+    << dirty_expire_time_centisecs << endl;
   const char* old_expire_time =
     test_harness.update_dirty_expire_time(dirty_expire_time_centisecs.c_str());
   if (old_expire_time == NULL) {
@@ -583,7 +591,12 @@ int main(int argc, char** argv) {
             wait_res = waitpid(child, &status, WNOHANG);
           } while (wait_res == 0);
           if (status != 0) {
-            cerr << "Error in test process" << endl;
+            if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
+              cerr << "Error in test process, exited with status "
+                << WEXITSTATUS(status) << endl;
+            } else {
+              cerr << "Error in test process" << endl;
+            }
             test_harness.cleanup_harness();
             return -1;
           }

--- a/code/permuter/Permuter.cpp
+++ b/code/permuter/Permuter.cpp
@@ -56,6 +56,7 @@ void Permuter::InitDataVector(vector<disk_write> *data) {
   // Make sure that the first time we mark a checkpoint epoch, we start at 0 and
   // not 1.
   unsigned int curr_checkpoint_epoch = 0;
+  // Aligns with the index of the bio in the profile dump, 0 indexed.
   unsigned int abs_index = 0;
 
   auto curr_op = data->begin();
@@ -77,12 +78,15 @@ void Permuter::InitDataVector(vector<disk_write> *data) {
         // Checkpoint operations should not appear in the bio stream passed to
         // actual permuters.
         ++curr_op;
+        ++abs_index;
         continue;
       }
       
       if (prev_epoch_flush_op == true) {
         epoch_op split_op = {abs_index, data_half};
-        ++abs_index;
+        // TODO(ashmrtn): Find a better way to handle matching an index to a bio
+        // in the profile dump.
+        //++abs_index;
         current_epoch.ops.push_back(split_op);
         current_epoch.num_meta += data_half.is_meta();
         prev_epoch_flush_op = false;

--- a/code/results/TestSuiteResult.cpp
+++ b/code/results/TestSuiteResult.cpp
@@ -6,6 +6,7 @@ namespace fs_testing {
 
 using std::endl;
 using std::ostream;
+using std::string;
 using std::vector;
 
 using fs_testing::tests::DataTestResult;
@@ -34,20 +35,25 @@ void TestSuiteResult::PrintResults(ostream& os, bool is_log) const {
   unsigned int other = 0;
 
   for (const auto& result : completed_) {
+
+    string test_status("");
+    string des("");
     total_tests++;
     if (result.fs_test.GetError() == FileSystemTestResult::kClean
         && result.data_test.GetError() == DataTestResult::kClean) {
       ++num_passed;
+      test_status = "PASSED";
     } else if (result.fs_test.GetError() == FileSystemTestResult::kFixed
         && result.data_test.GetError() == DataTestResult::kClean) {
       ++num_passed_fixed;
+      test_status = "FSCK_FIXED";
     } else if (result.fs_test.GetError() ==
         FileSystemTestResult::kKernelMount &&
         result.data_test.GetError() == DataTestResult::kClean) {
       ++fsck_required;
     } else {
+      test_status = "FAILED";
       ++num_failed;
-      std::string des(""); 
       switch (result.data_test.GetError()) {
         case DataTestResult::kOldFilePersisted:
           des += "old file persisted: ";
@@ -70,14 +76,14 @@ void TestSuiteResult::PrintResults(ostream& os, bool is_log) const {
           ++other;
           break;
       }
-      if (is_log) {
-        os << "Test #" << total_tests << " FAILED: " << des
-          << result.data_test.error_description << endl;
-        os << "\tlast checkpoint: " << result.permute_data.last_checkpoint
-          << endl;
-        os << "\tcrash state: ";
-        result.permute_data.PrintCrashState(os) << endl;
-      }
+    }
+    if (is_log) {
+      os << "Test #" << total_tests << ": " << test_status << ": " << des
+        << result.data_test.error_description << endl;
+      os << "\tlast checkpoint: " << result.permute_data.last_checkpoint
+        << endl;
+      os << "\tcrash state: ";
+      result.permute_data.PrintCrashState(os) << endl;
     }
   }
 


### PR DESCRIPTION
Includes changes for how dirty_writeback_centiseconds is changed, logging info
during testing, and some print statements.