### PR TITLE
Consolidate logging information

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -83,6 +83,7 @@ $(BUILD_DIR)/c_harness: \
 		$(BUILD_DIR)/utils/communication/BaseSocket.o \
 		$(BUILD_DIR)/permuter/Permuter.o \
 		$(BUILD_DIR)/results/TestSuiteResult.o \
+		$(BUILD_DIR)/results/SingleTestInfo.o \
 		$(BUILD_DIR)/results/FileSystemTestResult.o \
 		$(BUILD_DIR)/results/DataTestResult.o \
 		$(BUILD_DIR)/results/PermuteTestResult.o
@@ -123,7 +124,7 @@ $(BUILD_DIR)/permuter/%.so: \
 		$(BUILD_DIR)/utils/utils_c.o
 	mkdir -p $(@D)
 	$(GPP) $(GOPTS) $(GOTPSSO) -Wl,-soname,RandomPermuter.so \
-		-o $(BUILD_DIR)/permuter/RandomPermuter.so $^
+		-o $@ $^
 
 $(BUILD_DIR)/utils/utils.o: \
 		utils/utils.cpp

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <cerrno>
+#include <cstdio>
 #include <cstdlib>
 
 #include <algorithm>
@@ -14,6 +15,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <string>
 
 #include "../disk_wrapper_ioctl.h"
 #include "Tester.h"
@@ -81,6 +83,7 @@ using std::ostream;
 using std::ofstream;
 using std::shared_ptr;
 using std::string;
+using std::to_string;
 using std::vector;
 
 using fs_testing::tests::test_create_t;
@@ -459,7 +462,8 @@ int Tester::test_run() {
   return test_loader.get_instance()->run();
 }
 
-int Tester::test_check_random_permutations(const int num_rounds) {
+int Tester::test_check_random_permutations(const int num_rounds,
+    ofstream& log) {
   time_point<steady_clock> start_time = steady_clock::now();
   TestSuiteResult test_suite;
   Permuter *p = permuter_loader.get_instance();
@@ -489,12 +493,9 @@ int Tester::test_check_random_permutations(const int num_rounds) {
       break;
     }
 
-    //cout << '.' << std::flush;
-
     // Restore disk clone.
     int cow_brd_snapshot_fd = open(SNAPSHOT_PATH, O_WRONLY);
     if (cow_brd_snapshot_fd < 0) {
-      cerr << "error opening snapshot to write permuted bios" << endl;
       test_info.fs_test.SetError(FileSystemTestResult::kSnapshotRestore);
       continue;
     }
@@ -510,10 +511,8 @@ int Tester::test_check_random_permutations(const int num_rounds) {
         duration_cast<milliseconds>(snapshot_end_time - snapshot_start_time);
     // End snapshot timing.
 
-    if (verbose) {
-      std::cout << "Test #" << rounds + 1 << ": Writing " << permutes.size()
-        << " operations to disk" << std::endl;
-    }
+    log << "Test #" << rounds + 1 << ": Writing " << permutes.size()
+      << " operations to disk" << std::endl;
 
     // Write recorded data out to block device in different orders so that we
     // can if they are all valid or not.
@@ -543,20 +542,36 @@ int Tester::test_check_random_permutations(const int num_rounds) {
     }
     umount_device();
 
-    if (verbose) {
-      std::cout << "Running fsck" << std::endl;
-    }
+    log << "Running fsck" << std::endl;
     string command(TEST_CASE_FSCK + fs_type + " " + SNAPSHOT_PATH
-        + " -- -yf");
-    if (!verbose) {
-      command += SILENT;
-    }
+        + " -- -y 2>&1");
+
     // Begin fsck timing.
     time_point<steady_clock> fsck_start_time = steady_clock::now();
-    test_info.fs_test.fs_check_return = system(command.c_str());
+
+    // Use popen so that we can throw all the output from fsck into the log that
+    // we are keeping. This information will go just before the summary of what
+    // went wrong in the test.
+    FILE *pipe = popen(command.c_str(), "r");
+    char tmp[128];
+    if (!pipe) {
+      test_info.fs_test.SetError(FileSystemTestResult::kOther);
+      test_info.fs_test.error_description = "error running fsck";
+      continue;
+    }
+    while (!feof(pipe)) {
+      char *r = fgets(tmp, 128, pipe);
+      // NULL can be returned on error.
+      if (r != NULL) {
+        log << tmp;
+        test_info.fs_test.fsck_result += tmp;
+      }
+    }
+    const int fsck_res = pclose(pipe);
     time_point<steady_clock> fsck_end_time = steady_clock::now();
     timing_stats[FSCK_TIME] +=
         duration_cast<milliseconds>(fsck_end_time - fsck_start_time);
+
     // End fsck timing.
     if (!(test_info.fs_test.fs_check_return == 0
           || WEXITSTATUS(test_info.fs_test.fs_check_return) == 1)) {
@@ -565,6 +580,8 @@ int Tester::test_check_random_permutations(const int num_rounds) {
         WEXITSTATUS(fsck_res) << "\n";
       */
       test_info.fs_test.SetError(FileSystemTestResult::kCheck);
+      test_info.fs_test.error_description =
+        string("exit status ") + to_string(WEXITSTATUS(fsck_res));
       test_suite.AddCompletedTest(test_info);
       continue;
     }
@@ -592,13 +609,14 @@ int Tester::test_check_random_permutations(const int num_rounds) {
     }
     umount_device();
   }
-  //cout << endl;
   test_results_.push_back(test_suite);
   time_point<steady_clock> end_time = steady_clock::now();
   timing_stats[TOTAL_TIME] = duration_cast<milliseconds>(end_time - start_time);
 
   if (test_suite.GetCompleted() < num_rounds) {
     cout << "=============== Unable to find new unique state, stopping at "
+      << test_suite.GetCompleted() << " tests ===============" << endl << endl;
+    log << "=============== Unable to find new unique state, stopping at "
       << test_suite.GetCompleted() << " tests ===============" << endl << endl;
   }
   return SUCCESS;

--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -115,7 +115,7 @@ class Tester {
 
   std::chrono::milliseconds get_timing_stat(time_stats timing_stat);
   void PrintTimingStats(std::ostream& os);
-  void PrintTestStats(std::ostream& os, bool is_log);
+  void PrintTestStats(std::ostream& os);
 
   // TODO(ashmrtn): Figure out why making these private slows things down a lot.
  private:

--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -2,6 +2,7 @@
 #define TESTER_H
 
 #include <chrono>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -81,7 +82,7 @@ class Tester {
   int test_init_values(std::string mountDir, long filesysSize);
   int test_run();
   int test_check_permutations(const int num_rounds);
-  int test_check_random_permutations(const int num_rounds);
+  int test_check_random_permutations(const int num_rounds, std::ofstream& log);
   int test_restore_log();
   int test_check_current();
 

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -148,13 +148,30 @@ int main(int argc, char** argv) {
    ****************************************************************************/
   const unsigned int test_case_idx = optind;
   const string path = argv[test_case_idx];
-  //this should be changed in the option is added to mount tests in other directories
+
+  // Get the name of the test being run.
+  int begin = path.rfind('/');
+  // Remove everything before the last /.
+  string test_name = path.substr(begin + 1);
+  // Remove the extension.
+  test_name = test_name.substr(0, test_name.length() - 3);
+  // Get the date and time stamp and format.
+  time_t now = time(0);
+  char time_st[18];
+  strftime(time_st, sizeof(time_st), "%Y%m%d_%H%M%S", localtime(&now));
+  string s = string(time_st) + "-" + test_name + ".log";
+  ofstream logfile(s);
+
+  // This should be changed in the option is added to mount tests in other
+  // directories.
   string mount_dir = "/mnt/snapshot"; 
   if(setenv("MOUNT_FS", mount_dir.c_str(), 1) == -1){
     cerr << "Error setting environment variable MOUNT_FS" << endl;
   }
   
   cout << "========== PHASE 0: Setting up CrashMonkey basics =========="
+    << endl;
+  logfile << "========== PHASE 0: Setting up CrashMonkey basics =========="
     << endl;
   if (test_case_idx == argc) {
     cerr << "Please give a .so test case to load" << endl;
@@ -221,6 +238,7 @@ int main(int argc, char** argv) {
   Tester test_harness(disk_size, verbose);
 
   cout << "Inserting RAM disk module" << endl;
+  logfile << "Inserting RAM disk module" << endl;
   if (test_harness.insert_cow_brd() != SUCCESS) {
     cerr << "Error inserting RAM disk module" << endl;
     return -1;
@@ -267,6 +285,7 @@ int main(int argc, char** argv) {
   // TODO(ashmrtn): Consider making a line in the test file which specifies the
   // permuter to use?
   cout << "Loading permuter" << endl;
+  logfile << "Loading permuter" << endl;
   if (test_harness.permuter_load_class(permuter.c_str()) != SUCCESS) {
     test_harness.cleanup_harness();
       return -1;
@@ -274,6 +293,8 @@ int main(int argc, char** argv) {
 
   // Update dirty_expire_time.
   cout << "Updating dirty_expire_time_centisecs to "
+    << dirty_expire_time_centisecs << endl;
+  logfile << "Updating dirty_expire_time_centisecs to "
     << dirty_expire_time_centisecs << endl;
   const char* old_expire_time =
     test_harness.update_dirty_expire_time(dirty_expire_time_centisecs.c_str());
@@ -300,6 +321,8 @@ int main(int argc, char** argv) {
 
   cout << endl << "========== PHASE 1: Creating base disk image =========="
     << endl;
+  logfile << endl << "========== PHASE 1: Creating base disk image =========="
+    << endl;
   // Run the normal test setup stuff if we don't have a log file.
   if (log_file_load.empty()) {
     /***************************************************************************
@@ -315,6 +338,7 @@ int main(int argc, char** argv) {
 
     // Format test drive to desired type.
     cout << "Formatting test drive" << endl;
+    logfile << "Formatting test drive" << endl;
     if (test_harness.format_drive() != SUCCESS) {
       cerr << "Error formatting test drive" << endl;
       test_harness.cleanup_harness();
@@ -323,6 +347,7 @@ int main(int argc, char** argv) {
 
     // Mount test file system for pre-test setup.
     cout << "Mounting test file system for pre-test setup" << endl;
+    logfile << "Mounting test file system for pre-test setup" << endl;
     if (test_harness.mount_device_raw(mount_opts.c_str()) != SUCCESS) {
       cerr << "Error mounting test device" << endl;
       test_harness.cleanup_harness();
@@ -333,6 +358,7 @@ int main(int argc, char** argv) {
 
     if (background) {
       cout << "+++++ Please run any needed pre-test setup +++++" << endl;
+      logfile << "+++++ Please run any needed pre-test setup +++++" << endl;
       /*************************************************************************
        * Background mode user setup. Wait for the user to tell use that they
        * have finished the pre-test setup phase.
@@ -364,11 +390,13 @@ int main(int argc, char** argv) {
        * cleanliness.
        ************************************************************************/
       cout << "Running pre-test setup" << endl;
+      logfile << "Running pre-test setup" << endl;
       {
         const pid_t child = fork();
         if (child < 0) {
           cerr << "Error creating child process to run pre-test setup" << endl;
           test_harness.cleanup_harness();
+          return -1;
         } else if (child != 0) {
           // Parent process should wait for child to terminate before proceeding.
           pid_t status;
@@ -376,6 +404,7 @@ int main(int argc, char** argv) {
           if (status != 0) {
             cerr << "Error in pre-test setup" << endl;
             test_harness.cleanup_harness();
+            return -1;
           }
         } else {
           return test_harness.test_setup();
@@ -389,6 +418,7 @@ int main(int argc, char** argv) {
      **************************************************************************/
     // Unmount the test file system after pre-test setup.
     cout << "Unmounting test file system after pre-test setup" << endl;
+    logfile << "Unmounting test file system after pre-test setup" << endl;
     if (test_harness.umount_device() != SUCCESS) {
       test_harness.cleanup_harness();
       return -1;
@@ -396,6 +426,7 @@ int main(int argc, char** argv) {
 
     // Create snapshot of disk for testing.
     cout << "Making new snapshot" << endl;
+    logfile << "Making new snapshot" << endl;
     if (test_harness.clone_device() != SUCCESS) {
       test_harness.cleanup_harness();
       return -1;
@@ -409,6 +440,7 @@ int main(int argc, char** argv) {
        * base image for our snapshots.
        ************************************************************************/
       cout << "Saving snapshot to log file" << endl;
+      logfile << "Saving snapshot to log file" << endl;
       if (test_harness.log_snapshot_save(log_file_save + "_snap")
           != SUCCESS) {
         test_harness.cleanup_harness();
@@ -422,6 +454,7 @@ int main(int argc, char** argv) {
      **************************************************************************/
     // Load the snapshot in the log file and then write it to disk.
     cout << "Loading saved snapshot" << endl;
+    logfile << "Loading saved snapshot" << endl;
     if (test_harness.log_snapshot_load(log_file_load + "_snap") != SUCCESS) {
       test_harness.cleanup_harness();
       return -1;
@@ -445,8 +478,11 @@ int main(int argc, char** argv) {
 
   cout << endl << "========== PHASE 2: Recording user workload =========="
     << endl;
+  logfile << endl << "========== PHASE 2: Recording user workload =========="
+    << endl;
   // TODO(ashmrtn): Consider making a flag for this?
   cout << "Clearing caches" << endl;
+  logfile << "Clearing caches" << endl;
   if (test_harness.clear_caches() != SUCCESS) {
     cerr << "Error clearing caches" << endl;
     test_harness.cleanup_harness();
@@ -461,15 +497,16 @@ int main(int argc, char** argv) {
 
     // Insert the disk block wrapper into the kernel.
     cout << "Inserting wrapper module into kernel" << endl;
+    logfile << "Inserting wrapper module into kernel" << endl;
     if (test_harness.insert_wrapper() != SUCCESS) {
       cerr << "Error inserting kernel wrapper module" << endl;
       test_harness.cleanup_harness();
       return -1;
     }
 
-
     // Get access to wrapper module ioctl functions via FD.
     cout << "Getting wrapper device ioctl fd" << endl;
+    logfile << "Getting wrapper device ioctl fd" << endl;
     if (test_harness.get_wrapper_ioctl() != SUCCESS) {
       cerr << "Error opening device file" << endl;
       test_harness.cleanup_harness();
@@ -478,8 +515,10 @@ int main(int argc, char** argv) {
 
     // Clear wrapper module logs prior to test profiling.
     cout << "Clearing wrapper device logs" << endl;
+    logfile << "Clearing wrapper device logs" << endl;
     test_harness.clear_wrapper_log();
     cout << "Enabling wrapper device logging" << endl;
+    logfile << "Enabling wrapper device logging" << endl;
     test_harness.begin_wrapper_logging();
 
     // We also need to log the changes made by mount of the FS
@@ -520,6 +559,7 @@ int main(int argc, char** argv) {
       background_com->CloseClient();
 
       cout << "+++++ Please run workload +++++" << endl;
+      logfile << "+++++ Please run workload +++++" << endl;
 
       // Wait for the user to tell us they are done with the workload.
       SocketMessage command;
@@ -577,6 +617,7 @@ int main(int argc, char** argv) {
        * due to a busy mount point.
        ************************************************************************/
       cout << "Running test profile" << endl;
+      logfile << "Running test profile" << endl;
       {
         const pid_t child = fork();
         if (child < 0) {
@@ -654,17 +695,21 @@ int main(int argc, char** argv) {
     // Wait a small amount of time for writes to propogate to the block
     // layer and then stop logging writes.
     cout << "Waiting for writeback delay" << endl;
+    logfile << "Waiting for writeback delay" << endl;
     sleep(WRITE_DELAY);
 
     cout << "Disabling wrapper device logging" << endl;
+    logfile << "Disabling wrapper device logging" << endl;
     test_harness.end_wrapper_logging();
     cout << "Getting wrapper data" << endl;
+    logfile << "Getting wrapper data" << endl;
     if (test_harness.get_wrapper_log() != SUCCESS) {
       test_harness.cleanup_harness();
       return -1;
     }
 
     cout << "Unmounting wrapper file system after test profiling" << endl;
+    logfile << "Unmounting wrapper file system after test profiling" << endl;
     if (test_harness.umount_device() != SUCCESS) {
       cerr << "Error unmounting wrapper file system" << endl;
       test_harness.cleanup_harness();
@@ -672,8 +717,10 @@ int main(int argc, char** argv) {
     }
 
     cout << "Close wrapper ioctl fd" << endl;
+    logfile << "Close wrapper ioctl fd" << endl;
     test_harness.put_wrapper_ioctl();
     cout << "Removing wrapper module from kernel" << endl;
+    logfile << "Removing wrapper module from kernel" << endl;
     if (test_harness.remove_wrapper() != SUCCESS) {
       cerr << "Error cleaning up: remove wrapper module" << endl;
       test_harness.cleanup_harness();
@@ -688,6 +735,7 @@ int main(int argc, char** argv) {
        * logged so they can be reused later if the -r flag is given.
        ************************************************************************/
       cout << "Saving logged profile data to disk" << endl;
+      logfile << "Saving logged profile data to disk" << endl;
       if (test_harness.log_profile_save(log_file_save + "_profile") != SUCCESS) {
         cerr << "Error saving logged test file" << endl;
         // TODO(ashmrtn): Remove this in later versions?
@@ -717,6 +765,7 @@ int main(int argc, char** argv) {
      * log file. Load the series of disk epochs which we will be operating on.
      **************************************************************************/
     cout << "Loading logged profile data from disk" << endl;
+    logfile << "Loading logged profile data from disk" << endl;
     if (test_harness.log_profile_load(log_file_load + "_profile") != SUCCESS) {
       cerr << "Error loading logged test file" << endl;
       test_harness.cleanup_harness();
@@ -743,6 +792,7 @@ int main(int argc, char** argv) {
     SocketMessage command;
     do {
       cout << "+++++ Ready to run tests, please confirm start +++++" << endl;
+      logfile << "+++++ Ready to run tests, please confirm start +++++" << endl;
       if (background_com->WaitForMessage(&command) != SocketError::kNone) {
         cerr << "Error getting command from socket" << endl;
         delete background_com;
@@ -766,6 +816,9 @@ int main(int argc, char** argv) {
   cout << endl
     << "========== PHASE 3: Running tests based on recorded data =========="
     << endl;
+  logfile << endl
+    << "========== PHASE 3: Running tests based on recorded data =========="
+    << endl;
 
 
   // TODO(ashmrtn): Fix the meaning of "dry-run". Right now it means do
@@ -774,24 +827,16 @@ int main(int argc, char** argv) {
     /***************************************************************************
      * Run tests and print the results of said tests.
      **************************************************************************/
-    cout << "Writing profiled data to block device and checking with fsck" << endl;
+    cout << "Writing profiled data to block device and checking with fsck" <<
+      endl;
+    logfile << "Writing profiled data to block device and checking with fsck" <<
+      endl;
 
-    // Get the name of the test being run.
-    int begin = path.rfind('/');
-    // Remove everything before the last /.
-    string test_name = path.substr(begin + 1);
-    // Remove the extension.
-    test_name = test_name.substr(0, test_name.length() - 3);
-    // Get the date and time stamp and format.
-    time_t now = time(0);
-    char time_st[18];
-    strftime(time_st, sizeof(time_st), "%Y%m%d_%H%M%S", localtime(&now));
-    string s = string(time_st) + "-" + test_name + ".log";
-    ofstream logfile(s);
     test_harness.test_check_random_permutations(iterations, logfile);
+    test_harness.PrintTestStats(logfile);
     test_harness.remove_cow_brd();
 
-    test_harness.PrintTestStats(cout, false);
+    test_harness.PrintTestStats(cout);
     cout << endl;
 
     for (unsigned int i = 0; i < Tester::NUM_TIME; ++i) {
@@ -799,17 +844,17 @@ int main(int argc, char** argv) {
         << test_harness.get_timing_stat((Tester::time_stats) i).count() << " ms"
         << endl;
     }
-    //test_harness.PrintTestStats(logfile, true);
-    logfile.close();
   }
 
   cout << endl << "========== PHASE 4: Cleaning up ==========" << endl;
+  logfile << endl << "========== PHASE 4: Cleaning up ==========" << endl;
 
   /*****************************************************************************
    * PHASE 4:
    * We have finished. Clean up the test harness. Tell the user we have finished
    * testing if the -b flag was given and we are running in background mode.
    ****************************************************************************/
+  logfile.close();
   test_harness.cleanup_harness();
 
   if (background) {

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -8,6 +8,7 @@
 #include <wait.h>
 
 #include <ctime>
+
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -43,6 +44,7 @@ namespace {
 using std::cerr;
 using std::cout;
 using std::endl;
+using std::ofstream;
 using std::string;
 using std::to_string;
 using fs_testing::Tester;
@@ -773,7 +775,20 @@ int main(int argc, char** argv) {
      * Run tests and print the results of said tests.
      **************************************************************************/
     cout << "Writing profiled data to block device and checking with fsck" << endl;
-    test_harness.test_check_random_permutations(iterations);
+
+    // Get the name of the test being run.
+    int begin = path.rfind('/');
+    // Remove everything before the last /.
+    string test_name = path.substr(begin + 1);
+    // Remove the extension.
+    test_name = test_name.substr(0, test_name.length() - 3);
+    // Get the date and time stamp and format.
+    time_t now = time(0);
+    char time_st[18];
+    strftime(time_st, sizeof(time_st), "%Y%m%d_%H%M%S", localtime(&now));
+    string s = string(time_st) + "-" + test_name + ".log";
+    ofstream logfile(s);
+    test_harness.test_check_random_permutations(iterations, logfile);
     test_harness.remove_cow_brd();
 
     test_harness.PrintTestStats(cout, false);
@@ -784,19 +799,7 @@ int main(int argc, char** argv) {
         << test_harness.get_timing_stat((Tester::time_stats) i).count() << " ms"
         << endl;
     }
-    //get the name of the test being run 
-    int begin = path.rfind('/');
-    //remove everything before the last /
-    string test_name = path.substr(begin + 1);
-    //remove the extension 
-    test_name = test_name.substr(0, test_name.length() - 3); 
-    //get the date and time stamp and format
-    time_t now = time(0); 
-    char time_st[18];
-    strftime(time_st, sizeof(time_st), "%Y%m%d_%H:%M:%S", localtime(&now));  
-    string s = string(time_st) + "-" + test_name + ".log";
-    std::ofstream logfile (s);
-    test_harness.PrintTestStats(logfile, true);
+    //test_harness.PrintTestStats(logfile, true);
     logfile.close();
   }
 

--- a/code/results/DataTestResult.cpp
+++ b/code/results/DataTestResult.cpp
@@ -21,7 +21,7 @@ DataTestResult::ErrorType DataTestResult::GetError() const {
   return error_summary_;
 }
 
-ostream& DataTestResult::PrintErrors(ostream& os) {
+ostream& DataTestResult::PrintErrors(ostream& os) const {
   unsigned int noted_errors = error_summary_;
   unsigned int shift = 0;
   while (noted_errors != 0) {
@@ -37,6 +37,8 @@ ostream& DataTestResult::PrintErrors(ostream& os) {
 
 ostream& operator<<(ostream& os, DataTestResult::ErrorType err) {
   switch (err) {
+    case DataTestResult::kClean:
+      break;
     case DataTestResult::kOldFilePersisted:
       os << "old_file_persisted";
       break;

--- a/code/results/DataTestResult.h
+++ b/code/results/DataTestResult.h
@@ -32,7 +32,7 @@ class DataTestResult {
   void ResetError();
   void SetError(ErrorType errors);
   ErrorType GetError() const;
-  std::ostream& PrintErrors(std::ostream& os);
+  std::ostream& PrintErrors(std::ostream& os) const;
   std::string error_description;
 
  private:

--- a/code/results/FileSystemTestResult.cpp
+++ b/code/results/FileSystemTestResult.cpp
@@ -36,6 +36,8 @@ ostream& FileSystemTestResult::PrintErrors(ostream& os) {
 
 ostream& operator<<(ostream& os, FileSystemTestResult::ErrorType err) {
   switch (err) {
+    case fs_testing::FileSystemTestResult::kClean:
+      break;
     case fs_testing::FileSystemTestResult::kUnmountable:
       os << "unmountable_file_system";
       break;

--- a/code/results/FileSystemTestResult.h
+++ b/code/results/FileSystemTestResult.h
@@ -34,6 +34,7 @@ class FileSystemTestResult {
   ErrorType GetError() const;
   std::ostream& PrintErrors(std::ostream& os);
   std::string error_description;
+  std::string fsck_result;
 
   int fs_check_return;
 

--- a/code/results/SingleTestInfo.cpp
+++ b/code/results/SingleTestInfo.cpp
@@ -1,0 +1,68 @@
+#include "DataTestResult.h"
+#include "FileSystemTestResult.h"
+#include "SingleTestInfo.h"
+
+namespace fs_testing {
+
+using std::endl;
+using std::ostream;
+using std::string;
+using std::vector;
+
+using fs_testing::tests::DataTestResult;
+using fs_testing::FileSystemTestResult;
+
+SingleTestInfo::SingleTestInfo() {
+  fs_test.ResetError();
+  data_test.ResetError();
+}
+
+SingleTestInfo::ResultType SingleTestInfo::GetTestResult() const {
+  if (fs_test.GetError() == FileSystemTestResult::kClean
+      && data_test.GetError() == DataTestResult::kClean) {
+    return SingleTestInfo::kPassed;
+  } else if (fs_test.GetError() == FileSystemTestResult::kFixed
+      && data_test.GetError() == DataTestResult::kClean) {
+    return SingleTestInfo::kFsckFixed;
+  } else if (fs_test.GetError() == FileSystemTestResult::kKernelMount) {
+    return SingleTestInfo::kFsckRequired;
+  }
+  return SingleTestInfo::kFailed;
+}
+
+void SingleTestInfo::PrintResults(ostream& os) const {
+  os << "Test #" << test_num << ": " << GetTestResult() << ": ";
+  data_test.PrintErrors(os);
+  if (GetTestResult() == SingleTestInfo::kFailed &&
+      fs_test.GetError() == FileSystemTestResult::kCheck) {
+    os << fs_test.error_description << endl;
+  } else {
+    os << data_test.error_description << endl;
+  }
+  os << "\tcrash state (" << permute_data.crash_state.size() << " bios): ";
+  permute_data.PrintCrashState(os) << endl;
+  os << "\tlast checkpoint: " << permute_data.last_checkpoint << endl;
+  os << "\tfsck output:" << endl << fs_test.fsck_result << endl <<endl;
+}
+
+ostream& operator<<(ostream& os, SingleTestInfo::ResultType rt) {
+  switch (rt) {
+    case SingleTestInfo::kPassed:
+      os << "PASSED";
+      break;
+    case SingleTestInfo::kFsckFixed:
+      os << "FSCK_FIXED";
+      break;
+    case SingleTestInfo::kFsckRequired:
+      os << "FSCK_REQUIRED";
+      break;
+    case SingleTestInfo::kFailed:
+      os << "FAILED";
+      break;
+    default:
+      os.setstate(std::ios_base::failbit);
+  }
+  return os;
+}
+
+}  // namespace fs_testing

--- a/code/results/SingleTestInfo.h
+++ b/code/results/SingleTestInfo.h
@@ -18,12 +18,26 @@ namespace fs_testing {
 // 2. permutation of bios in final epoch of state
 // 3. results of user data consistency tests
 // 4. results of file system consistency tests and repair(s)
-struct SingleTestInfo {
-  // TODO(ashmrtn): Create class for crash state information.
+class SingleTestInfo {
+ public:
+  enum ResultType {
+    kPassed,
+    kFsckFixed,
+    kFsckRequired,
+    kFailed
+  };
+
+  SingleTestInfo();
+  void PrintResults(std::ostream& os) const;
+  SingleTestInfo::ResultType GetTestResult() const;
+
+  unsigned int test_num;
   fs_testing::tests::DataTestResult data_test;
   fs_testing::FileSystemTestResult fs_test;
   fs_testing::PermuteTestResult permute_data;
 };
+
+std::ostream& operator<<(std::ostream& os, SingleTestInfo::ResultType rt);
 
 }  // namespace fs_testing
 

--- a/code/results/TestSuiteResult.cpp
+++ b/code/results/TestSuiteResult.cpp
@@ -13,97 +13,61 @@ using fs_testing::tests::DataTestResult;
 using fs_testing::FileSystemTestResult;
 using fs_testing::SingleTestInfo;
 
-void TestSuiteResult::AddCompletedTest(const SingleTestInfo& done) {
-  completed_.push_back(done);
+void TestSuiteResult::TallyResult(SingleTestInfo& done) {
+  switch (done.GetTestResult()) {
+    case SingleTestInfo::kPassed:
+      ++num_passed_;
+      break;
+    case SingleTestInfo::kFsckFixed:
+      ++num_passed_fixed_;
+      break;
+    case SingleTestInfo::kFsckRequired:
+      ++fsck_required_;
+      break;
+    case SingleTestInfo::kFailed:
+      ++num_failed_;
+
+      switch (done.data_test.GetError()) {
+        case DataTestResult::kOldFilePersisted:
+          ++old_file_persisted_;
+          break;
+        case DataTestResult::kFileMissing:
+          ++file_missing_;
+          break;
+        case DataTestResult::kFileDataCorrupted:
+          ++file_data_corrupted_;
+          break;
+        case DataTestResult::kFileMetadataCorrupted:
+          ++file_metadata_corrupted_;
+          break;
+        case DataTestResult::kIncorrectBlockCount:
+          ++incorrect_block_count_;
+          break;    
+        case DataTestResult::kOther:
+          ++other_;
+          break;
+      }
+      break;
+  }
 }
 
 unsigned int TestSuiteResult::GetCompleted() const {
-  return completed_.size();
+  return num_passed_ + num_passed_fixed_ + fsck_required_ + num_failed_;
 }
 
-void TestSuiteResult::PrintResults(ostream& os, bool is_log) const {
-  unsigned int num_failed = 0;
-  unsigned int num_passed_fixed = 0;
-  unsigned int num_passed = 0;
-  unsigned int total_tests = 0;
-
-  unsigned int fsck_required = 0;
-  unsigned int old_file_persisted = 0;
-  unsigned int file_missing = 0;
-  unsigned int file_data_corrupted = 0;
-  unsigned int file_metadata_corrupted = 0;
-  unsigned int incorrect_block_count = 0;
-  unsigned int other = 0;
-
-  for (const auto& result : completed_) {
-
-    string test_status("");
-    string des("");
-    total_tests++;
-    if (result.fs_test.GetError() == FileSystemTestResult::kClean
-        && result.data_test.GetError() == DataTestResult::kClean) {
-      ++num_passed;
-      test_status = "PASSED";
-    } else if (result.fs_test.GetError() == FileSystemTestResult::kFixed
-        && result.data_test.GetError() == DataTestResult::kClean) {
-      ++num_passed_fixed;
-      test_status = "FSCK_FIXED";
-    } else if (result.fs_test.GetError() ==
-        FileSystemTestResult::kKernelMount &&
-        result.data_test.GetError() == DataTestResult::kClean) {
-      ++fsck_required;
-    } else {
-      test_status = "FAILED";
-      ++num_failed;
-      switch (result.data_test.GetError()) {
-        case DataTestResult::kOldFilePersisted:
-          des += "old file persisted: ";
-          ++old_file_persisted;
-          break;
-        case DataTestResult::kFileMissing:
-          des += "file missing: ";
-          ++file_missing;
-          break;
-        case DataTestResult::kFileDataCorrupted:
-          des += "file data corrupted: ";
-          ++file_data_corrupted;
-          break;
-        case DataTestResult::kFileMetadataCorrupted:
-          des += "file metadata corrupted: ";
-          ++file_metadata_corrupted;
-          break;
-        case DataTestResult::kIncorrectBlockCount:
-          des += "incorrect block count: ";
-          ++incorrect_block_count;
-          break;    
-        case DataTestResult::kOther:
-          des += "other: ";
-          ++other;
-          break;
-      }
-    }
-    if (is_log) {
-      os << "Test #" << total_tests << ": " << test_status << ": " << des
-        << result.data_test.error_description << endl;
-      os << "\tlast checkpoint: " << result.permute_data.last_checkpoint
-        << endl;
-      os << "\tcrash state: ";
-      result.permute_data.PrintCrashState(os) << endl;
-    }
-  }
-
-  os << "Ran " << num_failed + num_passed_fixed + num_passed << " tests with"
-    << "\n\tpassed cleanly: " << num_passed
-    << "\n\tpassed fixed: " << num_passed_fixed + fsck_required
-    << "\n\t\tfsck required: " << fsck_required
-    << "\n\t\tfsck fixed: " << num_passed_fixed
-    << "\n\tfailed: " << num_failed
-    << "\n\t\told file persisted: " << old_file_persisted
-    << "\n\t\tfile missing: " << file_missing
-    << "\n\t\tfile data corrupted: " << file_data_corrupted
-    << "\n\t\tfile metadata corrupted: " << file_metadata_corrupted
-    << "\n\t\tincorrect block count: " << incorrect_block_count    
-    << "\n\t\tother: " << other << endl;
+void TestSuiteResult::PrintResults(ostream& os) const {
+  os << "Ran " <<
+    num_failed_ + num_passed_fixed_ + num_passed_ + fsck_required_ <<
+    " tests with" <<
+    "\n\tpassed cleanly: " << num_passed_ <<
+    "\n\tpassed fixed: " << num_passed_fixed_ <<
+    "\n\tfsck required: " << fsck_required_ <<
+    "\n\tfailed: " << num_failed_ <<
+    "\n\t\told file persisted: " << old_file_persisted_ <<
+    "\n\t\tfile missing: " << file_missing_ <<
+    "\n\t\tfile data corrupted: " << file_data_corrupted_ <<
+    "\n\t\tfile metadata corrupted: " << file_metadata_corrupted_ <<
+    "\n\t\tother: " << other_ << endl;
 }
 
 }  // namespace fs_testing

--- a/code/results/TestSuiteResult.h
+++ b/code/results/TestSuiteResult.h
@@ -11,12 +11,24 @@ namespace fs_testing {
 
 class TestSuiteResult {
  public:
-  void AddCompletedTest(const fs_testing::SingleTestInfo& done);
+  void TallyResult(fs_testing::SingleTestInfo& r);
   unsigned int GetCompleted() const;
-  void PrintResults(std::ostream& os, bool is_log) const;
+  void PrintResults(std::ostream& os) const;
 
  private:
-  std::vector<fs_testing::SingleTestInfo> completed_;
+  unsigned int num_failed_ = 0;
+  unsigned int num_passed_fixed_ = 0;
+  unsigned int num_passed_ = 0;
+  unsigned int total_tests_ = 0;
+
+  unsigned int fsck_required_ = 0;
+  unsigned int old_file_persisted_ = 0;
+  unsigned int file_missing_ = 0;
+  unsigned int file_data_corrupted_ = 0;
+  unsigned int file_metadata_corrupted_ = 0;
+  unsigned int incorrect_block_count_ = 0;
+  unsigned int other_ = 0;
+
 };
 
 }  // namespace fs_testing


### PR DESCRIPTION
Per #65, consolidate information in the various log files. This patch moves the output from fsck to the same log that contains other information about individual test cases.

Each log file name contains the time of the run and the test that is run. The log file contains the stdout status information from CrashMonkey and individual test results appear in the log like the following:
```
Test #748: PASSED:
        crash state (20 bios): 1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 13, 17, 20, 12, 10, 21, 19, 11, 15, 16
        last checkpoint: 0
        fsck output:
e2fsck 1.42.13 (17-May-2015)
/dev/cow_ram_snapshot1_0: clean, 12/25688 files, 8947/102400 blocks


Test #749: PASSED:
        crash state (7 bios): 6, 5, 8, 4, 1, 2, 7
        last checkpoint: 0
        fsck output:
e2fsck 1.42.13 (17-May-2015)
/dev/cow_ram_snapshot1_0: clean, 12/25688 files, 8896/102400 blocks
```