### PR TITLE
Add checkpoint to detect states that crash after fdatasync

### DIFF
--- a/code/tests/eof_blocks_loss.cpp
+++ b/code/tests/eof_blocks_loss.cpp
@@ -7,12 +7,14 @@
 
 #include "BaseTestCase.h"
 #include "../user_tools/api/workload.h"
+#include "../user_tools/api/actions.h"
 #define TEST_FILE "test_file"
 #define TEST_MNT "/mnt/snapshot"
 
 using fs_testing::tests::DataTestResult;
 using fs_testing::user_tools::api::WriteData;
 using fs_testing::user_tools::api::WriteDataMmap;
+using fs_testing::user_tools::api::Checkpoint;
 
 #define TEST_FILE_PERMS  ((mode_t) (S_IRWXU | S_IRWXG | S_IRWXO))
 
@@ -55,7 +57,14 @@ class EOFBlocksLoss: public BaseTestCase {
       return -3;
     }
     
-    fdatasync(fd_reg);
+    if (fdatasync(fd_reg) < 0){
+      close(fd_reg);
+      return -4;
+    }
+
+    if (Checkpoint() < 0){
+      return -5;
+    }
     
     close(fd_reg);
     return 0;


### PR DESCRIPTION
Crashmonkey can reproduce the bug : https://patchwork.kernel.org/patch/10120293/
Loss of data blocks beyond the EOF when fallocate with KEEP_SIZE is followed by  fdatasync() and crash soon after (within the 5 second window).