### PR TITLE
Record bios and timestamps in log for user perusal.

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -134,7 +134,7 @@ $(BUILD_DIR)/utils/utils.o: \
 $(BUILD_DIR)/utils/utils_c.o: \
 		utils/utils_c.c
 	mkdir -p $(@D)
-	$(GCC) -c -o $@ $< -I /usr/src/linux-headers-$(shell uname -r)/include/
+	$(GCC) -fPIC -c -o $@ $< -I /usr/src/linux-headers-$(shell uname -r)/include/
 
 $(BUILD_DIR)/user_tools/%: \
 		user_tools/%.cpp \

--- a/code/disk_wrapper_ioctl.h
+++ b/code/disk_wrapper_ioctl.h
@@ -22,6 +22,7 @@ struct disk_write_op_meta {
   unsigned long long bi_rw;
   unsigned long write_sector;
   unsigned int size;
+  unsigned long long time_ns;
 };
 
 #endif

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <chrono>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -919,6 +920,20 @@ int Tester::log_snapshot_load(string log_file) {
     return LOG_CLONE_ERR;
   }
   return SUCCESS;
+}
+
+void Tester::log_disk_write_data(std::ostream &log) {
+  int digits = log.precision();
+  std::ios_base::fmtflags fflags = log.flags();
+  log.precision(6);
+  log << std::left << std::setw(5) << "bio #" << " " << std::setw(18) <<
+    "time" << " " << std::setw(18) << "sector" << " " << std::setw(18) <<
+    "size" << std::endl;
+  for (unsigned int i = 0; i < log_data.size(); ++i) {
+    log << std::setw(5) << i << ' ' << log_data[i];
+  }
+  log.precision(digits);
+  log.flags(fflags);
 }
 
 void Tester::PrintTestStats(std::ostream& os) {

--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -112,6 +112,7 @@ class Tester {
   int log_profile_load(std::string log_file);
   int log_snapshot_save(std::string log_file);
   int log_snapshot_load(std::string log_file);
+  void log_disk_write_data(std::ostream &log);
 
   std::chrono::milliseconds get_timing_stat(time_stats timing_stat);
   void PrintTimingStats(std::ostream& os);

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -727,6 +727,10 @@ int main(int argc, char** argv) {
       return -1;
     }
 
+    logfile << endl << endl << "Recorded workload:" << endl;
+    test_harness.log_disk_write_data(logfile);
+    logfile << endl << endl;
+
     // Write log data out to file if we're given a file.
     if (!log_file_save.empty()) {
       /*************************************************************************

--- a/code/results/TestSuiteResult.cpp
+++ b/code/results/TestSuiteResult.cpp
@@ -67,6 +67,7 @@ void TestSuiteResult::PrintResults(ostream& os) const {
     "\n\t\tfile missing: " << file_missing_ <<
     "\n\t\tfile data corrupted: " << file_data_corrupted_ <<
     "\n\t\tfile metadata corrupted: " << file_metadata_corrupted_ <<
+    "\n\t\tincorrect block count: " << incorrect_block_count_ <<
     "\n\t\tother: " << other_ << endl;
 }
 

--- a/code/utils/utils.cpp
+++ b/code/utils/utils.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 
 #include <fstream>
+#include <iomanip>
 #include <ios>
 #include <iostream>
 #include <memory>
@@ -198,21 +199,25 @@ disk_write disk_write::deserialize(ifstream& is) {
   return res;
 }
 
-/*
- * Output all data for a single object on a single line.
- */
-ofstream& operator<<(ofstream& fs, const disk_write& dw) {
-  fs << dw.metadata.bi_flags << " "
-    << dw.metadata.bi_rw << " "
-    << dw.metadata.write_sector << " "
-    << dw.metadata.size << " "
-    << dw.data;
-  return fs;
+std::string disk_write::flags_to_string(long long flags) {
+  const unsigned int flag_buf_size = 4096;
+  char *flag_buf = new char[flag_buf_size];
+  flag_buf[0] = '\0';
+  c_flags_to_string(flags, flag_buf, flag_buf_size);
+  std::string res(flag_buf);
+  delete[] flag_buf;
+  return res;
 }
 
 ostream& operator<<(ostream& os, const disk_write& dw) {
-  os << std::hex << std::showbase << dw.metadata.bi_rw << std::noshowbase
-    << std::dec;
+  os << std::dec << std::setw(18) << std::fixed <<
+    ((double) dw.metadata.time_ns) / 100000000 <<
+    " " << std::setw(18) << std::hex << std::showbase <<
+      dw.metadata.write_sector <<
+    " " << std::setw(18) << dw.metadata.size << std::endl <<
+    '\t' << "flags " << std::setw(18) << dw.metadata.bi_rw << std::noshowbase
+      << std::dec << ": " << disk_write::flags_to_string(dw.metadata.bi_rw) <<
+      endl;
   return os;
 }
 

--- a/code/utils/utils.cpp
+++ b/code/utils/utils.cpp
@@ -110,6 +110,7 @@ void disk_write::serialize(std::ofstream& fs, const disk_write& dw) {
   const uint64_t write_rw = htobe64(dw.metadata.bi_rw);
   const uint64_t write_write_sector = htobe64(dw.metadata.write_sector);
   const uint64_t write_size = htobe64(dw.metadata.size);
+  const uint64_t time_ns = htobe64(dw.metadata.time_ns);
   memcpy(buffer + buf_offset, &write_flags, sizeof(const uint64_t));
   buf_offset += sizeof(const uint64_t);
   memcpy(buffer + buf_offset, &write_rw, sizeof(const uint64_t));
@@ -117,6 +118,8 @@ void disk_write::serialize(std::ofstream& fs, const disk_write& dw) {
   memcpy(buffer + buf_offset, &write_write_sector, sizeof(const uint64_t));
   buf_offset += sizeof(const uint64_t);
   memcpy(buffer + buf_offset, &write_size, sizeof(const uint64_t));
+  buf_offset += sizeof(const uint64_t);
+  memcpy(buffer + buf_offset, &time_ns, sizeof(const uint64_t));
   buf_offset += sizeof(const uint64_t);
 
   // Write out the 4K buffer containing metadata for this log entry
@@ -158,7 +161,7 @@ disk_write disk_write::deserialize(ifstream& is) {
   assert(is);
 
   unsigned int buf_offset = 0;
-  uint64_t write_flags, write_rw, write_write_sector, write_size;
+  uint64_t write_flags, write_rw, write_write_sector, write_size, time_ns;
   memcpy(&write_flags, buffer + buf_offset, sizeof(uint64_t));
   buf_offset += sizeof(uint64_t);
   memcpy(&write_rw, buffer + buf_offset, sizeof(uint64_t));
@@ -167,6 +170,8 @@ disk_write disk_write::deserialize(ifstream& is) {
   buf_offset += sizeof(uint64_t);
   memcpy(&write_size, buffer + buf_offset, sizeof(uint64_t));
   buf_offset += sizeof(uint64_t);
+  memcpy(&time_ns, buffer + buf_offset, sizeof(uint64_t));
+  buf_offset += sizeof(uint64_t);
 
   disk_write_op_meta meta;
 
@@ -174,6 +179,7 @@ disk_write disk_write::deserialize(ifstream& is) {
   meta.bi_rw = be64toh(write_rw);
   meta.write_sector = be64toh(write_write_sector);
   meta.size = be64toh(write_size);
+  meta.time_ns = be64toh(time_ns);
 
   char *data = new char[meta.size];
   for (unsigned int i = 0; i < meta.size; i += kSerializeBufSize) {

--- a/code/utils/utils.h
+++ b/code/utils/utils.h
@@ -23,7 +23,6 @@ class disk_write {
   void operator=(const disk_write& other);
   friend bool operator==(const disk_write& a, const disk_write& b);
   friend bool operator!=(const disk_write& a, const disk_write& b);
-  friend std::ofstream& operator<<(std::ofstream& os, const disk_write& dw);
 
   bool has_write_flag();
   bool is_barrier_write();
@@ -39,6 +38,7 @@ class disk_write {
   void clear_flush_seq_flag();
 
 
+  static std::string flags_to_string(long long flags);
   static void serialize(std::ofstream& fs, const disk_write& dw);
   static disk_write deserialize(std::ifstream& is);
 

--- a/code/utils/utils_c.c
+++ b/code/utils/utils_c.c
@@ -2,8 +2,37 @@
 // Created by Fábio Domingues on 19/07/17.
 //
 
-#include "utils_c.h"
+#include <assert.h>
 #include <linux/blk_types.h>
+#include <linux/version.h>
+#include <string.h>
+
+#include "utils_c.h"
+
+  static const char* const flag_names[] = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) \
+  && LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)
+    "write", "fail fast dev", "fail fast transport", "fail fast driver", "sync",
+    "meta", "prio", "discard", "secure", "write same", "no idle", "fua",
+    "flush", "read ahead", "throttled", "sorted", "soft barrier", "no merge",
+    "started", "don't prep", "queued", "elv priv", "failed", "quiet", "preempt",
+    "alloced", "copy user", "flush seq", "io stat", "mixed merge", "kernel",
+    "pm", "end", "nr bits"
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) \
+  && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+    "write", "fail fast dev", "fail fast transport", "fail fast driver", "sync",
+    "meta", "prio", "discard", "secure", "write same", "no idle", "fua",
+    "flush", "read ahead", "throttled", "sorted", "soft barrier", "no merge",
+    "started", "don't prep", "queued", "elv priv", "failed", "quiet", "preempt",
+    "alloced", "copy user", "flush seq", "io stat", "mixed merge", "pm",
+    "hashed", "mq_inflight", "no timeout", "nr bits"
+#else
+#error "Unsupported kernel version: CrashMonkey has not been tested with " \
+       "your kernel version."
+#endif
+};
+
+static char const checkpoint_name[] = "checkpoint";
 
 bool c_is_async_write(struct disk_write_op_meta *m) {
   return !((m->bi_rw & REQ_SYNC) ||
@@ -60,4 +89,35 @@ void c_clear_flush_flag(struct disk_write_op_meta *m) {
 
 void c_clear_flush_seq_flag(struct disk_write_op_meta *m) {
   m->bi_rw = (m->bi_rw & ~(REQ_FLUSH_SEQ));
+}
+
+void c_flags_to_string(long long flags, char *buf, unsigned int buf_len) {
+  unsigned int tmp_size;
+  unsigned int i;
+  // Start with remaining one less than length because we need a null
+  // terminating character.
+  unsigned int remaining = buf_len - 1;
+  // To find if we have enough space to concatonate, we need to make sure we
+  // have at least three more slots in the buffer, one for the trailing ',', one
+  // for the trailing ' ', and one for the null character. When checking the
+  // size of a string, we can check that it is the remaining size - 2 because
+  // this will tell us if it is longer than the remaining size - 3 which is the
+  // max we can handle.
+  if (flags & HWM_CHECKPOINT_FLAG) {
+    tmp_size = strnlen(checkpoint_name, remaining - 2);
+    assert(tmp_size <= remaining - 3);
+    strcat(buf, checkpoint_name);
+    strcat(buf, ", ");
+    remaining -= tmp_size - 3;
+  }
+
+  for (i = __REQ_WRITE; i < __REQ_NR_BITS; i++) {
+    if (flags & (1ULL << i)) {
+      tmp_size = strnlen(flag_names[i], remaining - 2);
+      assert(tmp_size <= remaining - 3);
+      strcat(buf, flag_names[i]);
+      strcat(buf, ", ");
+      remaining -= tmp_size - 3;
+    }
+  }
 }

--- a/code/utils/utils_c.h
+++ b/code/utils/utils_c.h
@@ -27,6 +27,8 @@ void c_set_flush_seq_flag(struct disk_write_op_meta *m);
 void c_clear_flush_flag(struct disk_write_op_meta *m);
 void c_clear_flush_seq_flag(struct disk_write_op_meta *m);
 
+void c_flags_to_string(long long flags, char *buf, unsigned int bluf_len);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Begin recording the time checkpoints and bios are sent to the disk wrapper. Also record the bio numbers, flags, sector, time, etc. in the CrashMonkey output log.

The segment that contains bio information looks like the following:
```
Recorded workload:                                                               
  bio # time               sector             size                                 
  0     1715068.381973     0                  0                                    
    flags 0x8000000000000000: checkpoint,                                          
  1     1715068.399774     0x2                0x400                                
    flags 0x1411            : write, sync, no idle, flush,                         
  2     1715078.422935     0x18002            0x400                                
    flags 0x411             : write, sync, no idle,                                
  3     1715078.423310     0x18004            0x400                                
    flags 0x411             : write, sync, no idle,                                
  4     1715078.423464     0x18006            0x400                                
    flags 0x411             : write, sync, no idle,                                
  5     1715078.423561     0x18008            0x400                                
    flags 0x411             : write, sync, no idle,                                
  6     1715078.423664     0x1800a            0x400                                
    flags 0x411             : write, sync, no idle,                                
  7     1715078.423750     0x1800c            0x400                                
    flags 0x411             : write, sync, no idle,                                
  8     1715078.423833     0x1800e            0x400                                
    flags 0x411             : write, sync, no idle,                                
  9     1715078.423918     0x18010            0x400                                
    flags 0x411             : write, sync, no idle,                                
  10    1715078.424014     0x18012            0x400
```