### PR TITLE
Create Mode to Replay Log in Order

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ file to see a printout of what tests failed and why.
 `./c_harness -f /dev/vda -d /dev/cow_ram0 -t ext4 -e 10240 -l create -v tests/create_delete.so` This sets the size of the filesystem to 10MB (with a block size of 1024), and saves the snapshot to a log file named create. To load this snapshot and rerun the test, simply run:
 `./c_harness -f /dev/vda -d /dev/cow_ram0 -t ext4 -e 10240 -r create -v tests/create_delete.so` This is useful in cases where you modify the check_test method in the workload to add additional checks for each crash state (in this example - crashmonkey/code/tests/create_delete.cpp). As long as the bio sequence during profiling does not change, it is safe to rerun the tests by loading the saved profile with -r option.
 
+1. **Fdatasync Incorrect EOF Blocks Workload**. To run a workload that has an
+incorrect number of data blocks after a file fallocate and fdatasync followed by
+a computer crash (using the ext4 file system), use the following command:
+`./c_harness -f /dev/vda -d /dev/cow_ram0 -t ext4 -e 10240 -v -P tests/eof_blocks_loss.so`
+The `-P` flag tells CrashMonkey not to run tests which reorder the blocks in the
+recorded workload. Therefore, for this test, CrashMonkey will only replay the
+logged workload in order, stopping at each checkpoint in the log to run fsck and
+any provided user data tests. By default, both tests that reorder the logged
+workload and tests that just replay the workload in order are run.
+
 A full listing of flags for CrashMonkey can be found in `code/harness/c_harness.c`
 
 #### Running as a Background Process ####

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "../disk_wrapper_ioctl.h"
 #include "Tester.h"
@@ -72,6 +73,7 @@ namespace fs_testing {
 using std::calloc;
 using std::cerr;
 using std::chrono::steady_clock;
+using std::chrono::duration;
 using std::chrono::duration_cast;
 using std::chrono::milliseconds;
 using std::chrono::time_point;
@@ -82,6 +84,7 @@ using std::ifstream;
 using std::ios;
 using std::ostream;
 using std::ofstream;
+using std::pair;
 using std::shared_ptr;
 using std::string;
 using std::to_string;
@@ -93,6 +96,11 @@ using fs_testing::permuter::Permuter;
 using fs_testing::permuter::permuter_create_t;
 using fs_testing::permuter::permuter_destroy_t;
 using fs_testing::utils::disk_write;
+
+namespace {
+  constexpr char kExt4[] = "ext4";
+  constexpr char kErrMountRo[] = "errors=remount-ro";
+}  // namespace
 
 Tester::Tester(const unsigned int dev_size, const bool verbosity)
   : device_size(dev_size), verbose(verbosity) {}
@@ -108,6 +116,16 @@ void Tester::set_device(const string device_path) {
 
 void Tester::set_flag_device(const std::string device_path) {
   flags_device = device_path;
+}
+
+void Tester::StartTestSuite() {
+  // Construct a new element at the end of our vector.
+  test_results_.emplace_back();
+  current_test_suite_ = &test_results_.back();
+}
+
+void Tester::EndTestSuite() {
+  current_test_suite_ = NULL;
 }
 
 int Tester::clone_device() {
@@ -463,13 +481,109 @@ int Tester::test_run() {
   return test_loader.get_instance()->run();
 }
 
+/*
+ * Tests a block device with fsck (or equivalent) and the user test case
+ * provided.
+ *
+ * This function assumes that the block device is *not* mounted when the
+ * function is entered. The function will take care of mounting the device as
+ * needed and will unmount the device before exiting.
+ *
+ * On return, the amount of time it took for both fsck (or equivalent) and the
+ * user test case are returned in the pair <fsck, user_test>. If one or both of
+ * fsck and the user test is not run, then those values are returned as -1.
+ * Furthermore, the SingleTestInfo object is modified to reflect the results of
+ * fsck and the user test case.
+ */
+pair<milliseconds, milliseconds> Tester::test_fsck_and_user_test(
+    const string device_path, const unsigned int last_checkpoint,
+    SingleTestInfo &test_info) {
+  pair<milliseconds, milliseconds> res(duration<int, std::milli>(-1),
+      duration<int, std::milli>(-1));
+  // Try mounting the file system so that the kernel can clean up orphan lists
+  // and anything else it may need to so that fsck does a better job later if
+  // we run it.
+  string mount_opts("");
+  // If ext4, remount with "errors=remount-ro".
+  if (fs_type.compare(kExt4) == 0) {
+    if (!mount_opts.empty()) {
+      mount_opts += ",";
+    }
+    mount_opts += kErrMountRo;
+  }
+  if (mount_device(device_path.c_str(), mount_opts.c_str()) != SUCCESS) {
+    test_info.fs_test.SetError(FileSystemTestResult::kKernelMount);
+  }
+  umount_device();
+
+  // TODO(ashmrtn): Change this command for btrfs to use `btrfs check`.
+  string command(TEST_CASE_FSCK + fs_type + " " + device_path + " -- -y 2>&1");
+
+  // Begin fsck timing.
+  time_point<steady_clock> fsck_start_time = steady_clock::now();
+
+  // Use popen so that we can throw all the output from fsck into the log that
+  // we are keeping. This information will go just before the summary of what
+  // went wrong in the test.
+  FILE *pipe = popen(command.c_str(), "r");
+  char tmp[128];
+  if (!pipe) {
+    test_info.fs_test.SetError(FileSystemTestResult::kOther);
+    test_info.fs_test.error_description = "error running fsck";
+    time_point<steady_clock> fsck_end_time = steady_clock::now();
+    res.first = duration_cast<milliseconds>(fsck_end_time - fsck_start_time);
+    return res;
+  }
+  while (!feof(pipe)) {
+    char *r = fgets(tmp, 128, pipe);
+    // NULL can be returned on error.
+    if (r != NULL) {
+      test_info.fs_test.fsck_result += tmp;
+    }
+  }
+  test_info.fs_test.fs_check_return = pclose(pipe);
+  time_point<steady_clock> fsck_end_time = steady_clock::now();
+  res.first = duration_cast<milliseconds>(fsck_end_time - fsck_start_time);
+
+  // End fsck timing.
+  if (!(test_info.fs_test.fs_check_return == 0
+        || WEXITSTATUS(test_info.fs_test.fs_check_return) == 1)) {
+    test_info.fs_test.SetError(FileSystemTestResult::kCheck);
+    test_info.fs_test.error_description = string("exit status ") +
+      to_string(WEXITSTATUS(test_info.fs_test.fs_check_return));
+    return res;
+  }
+  // TODO(ashmrtn): Consider mounting with options specified for test
+  // profile?
+  if (mount_device(device_path.c_str(), NULL) != SUCCESS) {
+    test_info.fs_test.SetError(FileSystemTestResult::kUnmountable);
+    return res;
+  } else {
+    // Begin test case timing.
+    time_point<steady_clock> test_case_start_time = steady_clock::now();
+    const int test_check_res =
+        test_loader.get_instance()->check_test(last_checkpoint,
+                                               &test_info.data_test);
+    time_point<steady_clock> test_case_end_time = steady_clock::now();
+    res.second = duration_cast<milliseconds>(
+        test_case_end_time - test_case_start_time);
+    // End test case timing.
+
+    if (test_check_res == 0 && test_info.fs_test.fs_check_return != 0) {
+      test_info.fs_test.SetError(FileSystemTestResult::kFixed);
+    }
+  }
+  umount_device();
+  return res;
+}
+
 int Tester::test_check_random_permutations(const int num_rounds,
     ofstream& log) {
+  assert(current_test_suite_ != NULL);
   time_point<steady_clock> start_time = steady_clock::now();
   Permuter *p = permuter_loader.get_instance();
   p->InitDataVector(&log_data);
   vector<disk_write> permutes;
-  TestSuiteResult test_suite;
   for (int rounds = 0; rounds < num_rounds; ++rounds) {
     // Print status every 1024 iterations.
     if (rounds & (~((1 << 10) - 1)) && !(rounds & ((1 << 10) - 1))) {
@@ -501,7 +615,7 @@ int Tester::test_check_random_permutations(const int num_rounds,
     if (cow_brd_snapshot_fd < 0) {
       test_info.fs_test.SetError(FileSystemTestResult::kSnapshotRestore);
       test_info.PrintResults(log);
-      test_suite.TallyResult(test_info);
+      current_test_suite_->TallyReorderingResult(test_info);
       continue;
     }
     // Begin snapshot timing.
@@ -509,7 +623,7 @@ int Tester::test_check_random_permutations(const int num_rounds,
     if (clone_device_restore(cow_brd_snapshot_fd, false) != SUCCESS) {
       test_info.fs_test.SetError(FileSystemTestResult::kSnapshotRestore);
       test_info.PrintResults(log);
-      test_suite.TallyResult(test_info);
+      current_test_suite_->TallyReorderingResult(test_info);
       continue;
     }
     time_point<steady_clock> snapshot_end_time = steady_clock::now();
@@ -529,102 +643,141 @@ int Tester::test_check_random_permutations(const int num_rounds,
       test_info.fs_test.SetError(FileSystemTestResult::kBioWrite);
       close(cow_brd_snapshot_fd);
       test_info.PrintResults(log);
-      test_suite.TallyResult(test_info);
+      current_test_suite_->TallyReorderingResult(test_info);
       continue;
     }
     close(cow_brd_snapshot_fd);
 
-    /***************************************************************************
-     * Begin testing the crash state that was just written out.
-     **************************************************************************/
+    // Test the crash state that was just written out.
+    pair<milliseconds, milliseconds> check_res = test_fsck_and_user_test(
+        SNAPSHOT_PATH, test_info.permute_data.last_checkpoint, test_info);
+    test_info.PrintResults(log);
+    current_test_suite_->TallyReorderingResult(test_info);
 
-    // Try mounting the file system so that the kernel can clean up orphan lists
-    // and anything else it may need to so that fsck does a better job later if
-    // we run it.
-    if (mount_device(SNAPSHOT_PATH, "errors=remount-ro") != SUCCESS) {
-      test_info.fs_test.SetError(FileSystemTestResult::kKernelMount);
+    // Accounting for time it took to run the test.
+    if (check_res.first.count() > -1) {
+      timing_stats[FSCK_TIME] + check_res.first;
     }
-    umount_device();
-
-    string command(TEST_CASE_FSCK + fs_type + " " + SNAPSHOT_PATH
-        + " -- -y 2>&1");
-
-    // Begin fsck timing.
-    time_point<steady_clock> fsck_start_time = steady_clock::now();
-
-    // Use popen so that we can throw all the output from fsck into the log that
-    // we are keeping. This information will go just before the summary of what
-    // went wrong in the test.
-    FILE *pipe = popen(command.c_str(), "r");
-    char tmp[128];
-    if (!pipe) {
-      test_info.fs_test.SetError(FileSystemTestResult::kOther);
-      test_info.fs_test.error_description = "error running fsck";
-      test_info.PrintResults(log);
-      test_suite.TallyResult(test_info);
-      continue;
+    if (check_res.second.count() > -1) {
+      timing_stats[TEST_CASE_TIME] + check_res.second;
     }
-    while (!feof(pipe)) {
-      char *r = fgets(tmp, 128, pipe);
-      // NULL can be returned on error.
-      if (r != NULL) {
-        test_info.fs_test.fsck_result += tmp;
-      }
-    }
-    test_info.fs_test.fs_check_return = pclose(pipe);
-    time_point<steady_clock> fsck_end_time = steady_clock::now();
-    timing_stats[FSCK_TIME] +=
-        duration_cast<milliseconds>(fsck_end_time - fsck_start_time);
-
-    // End fsck timing.
-    if (!(test_info.fs_test.fs_check_return == 0
-          || WEXITSTATUS(test_info.fs_test.fs_check_return) == 1)) {
-      /*
-      cerr << "Error running fsck on snapshot file system: " <<
-        WEXITSTATUS(fsck_res) << "\n";
-      */
-      test_info.fs_test.SetError(FileSystemTestResult::kCheck);
-      test_info.fs_test.error_description = string("exit status ") +
-        to_string(WEXITSTATUS(test_info.fs_test.fs_check_return));
-      test_info.PrintResults(log);
-      test_suite.TallyResult(test_info);
-      continue;
-    }
-    // TODO(ashmrtn): Consider mounting with options specified for test
-    // profile?
-    if (mount_device(SNAPSHOT_PATH, NULL) != SUCCESS) {
-      test_info.fs_test.SetError(FileSystemTestResult::kUnmountable);
-      test_info.PrintResults(log);
-      test_suite.TallyResult(test_info);
-      continue;
-    } else {
-      // Begin test case timing.
-      time_point<steady_clock> test_case_start_time = steady_clock::now();
-      const int test_check_res =
-          test_loader.get_instance()->check_test(
-              test_info.permute_data.last_checkpoint, &test_info.data_test);
-      time_point<steady_clock> test_case_end_time = steady_clock::now();
-      timing_stats[TEST_CASE_TIME] += duration_cast<milliseconds>(
-        test_case_end_time - test_case_start_time);
-      // End test case timing.
-
-      if (test_check_res == 0 && test_info.fs_test.fs_check_return != 0) {
-        test_info.fs_test.SetError(FileSystemTestResult::kFixed);
-      }
-      test_info.PrintResults(log);
-      test_suite.TallyResult(test_info);
-    }
-    umount_device();
   }
-  test_results_.push_back(test_suite);
+
   time_point<steady_clock> end_time = steady_clock::now();
   timing_stats[TOTAL_TIME] = duration_cast<milliseconds>(end_time - start_time);
 
-  if (test_suite.GetCompleted() < num_rounds) {
-    cout << "=============== Unable to find new unique state, stopping at "
-      << test_suite.GetCompleted() << " tests ===============" << endl << endl;
-    log << "=============== Unable to find new unique state, stopping at "
-      << test_suite.GetCompleted() << " tests ===============" << endl << endl;
+  if (current_test_suite_->GetReorderingCompleted() < num_rounds) {
+    cout << "=============== Unable to find new unique state, stopping at " <<
+      current_test_suite_->GetReorderingCompleted() <<
+      " tests ===============" << endl << endl;
+    log << "=============== Unable to find new unique state, stopping at " <<
+      current_test_suite_->GetReorderingCompleted() <<
+      " tests ===============" << endl << endl;
+  }
+  return SUCCESS;
+}
+
+/*
+ * Replays the operations in the recorded workload, stopping at each Checkpoint
+ * found in the workload. At each Checkpoint, the user test case is called so
+ * that it can check that things are in order.
+ *
+ * TODO(ashmrtn): Should this call a separate method in the user test case or
+ * should it still call the check_test() method?
+ */
+int Tester::test_check_log_replay(std::ofstream& log) {
+  assert(current_test_suite_ != NULL);
+
+  // A single entry in the log data would just be the leading Checkpoint in the
+  // log. In this case, there are no tests to run, so just return.
+  if (log_data.size() == 1) {
+    return SUCCESS;
+  }
+
+  // Skip the first disk write as it is just the Checkpoint at the start of the
+  // log.
+  auto log_iter = log_data.begin() + 1;
+  vector<unsigned int> crash_state;
+  unsigned int crash_state_counter = 1;
+
+  while (log_iter != log_data.end()) {
+    // Keep going through the workload data log until we reach a Checkpoint.
+    // Also, skip the very first checkpoint which occurs at the very beginning
+    // of the log.
+    while (log_iter != log_data.end() &&
+        (!log_iter->is_checkpoint() || log_iter == log_data.begin())) {
+      crash_state.push_back(crash_state_counter);
+      ++crash_state_counter;
+      ++log_iter;
+    }
+
+    // Required since this is a nested loop and `break` in the inner loop would
+    // just exit that loop, but still run the tests below (which we should skip
+    // if we don't have a Checkpoint?).
+    //
+    // TODO(ashmrtn): See if we should test that the entire log replay
+    // (i.e. when we reach the end of the log. If so, delete the below check).
+    if (log_iter == log_data.end()) {
+      break;
+    }
+
+    // When we see a Checkpoint, we need to do several things:
+    // 0. Setup the test result struct with  info about this test
+    // 1. Restore the disk so that we start from a clean state
+    // 2. Write out the data in the log from the start until the checkpoint we
+    //    found
+    // 3. Test the resulting disk state with fsck and the user test case
+
+    // 0.
+    SingleTestInfo test_info;
+    test_info.permute_data.crash_state = crash_state;
+    // We reached the checkpoint, so it is indeed the last one we saw.
+    test_info.permute_data.last_checkpoint = log_iter->metadata.write_sector;
+    // Tests for this portion will be numbered starting from 1.
+    test_info.test_num = test_info.permute_data.last_checkpoint;
+
+    // 1. Restore disk clone.
+    int cow_brd_snapshot_fd = open(SNAPSHOT_PATH, O_WRONLY);
+    if (cow_brd_snapshot_fd < 0) {
+      test_info.fs_test.SetError(FileSystemTestResult::kSnapshotRestore);
+      test_info.PrintResults(log);
+      current_test_suite_->TallyTimingResult(test_info);
+      continue;
+    }
+    if (clone_device_restore(cow_brd_snapshot_fd, false) != SUCCESS) {
+      test_info.fs_test.SetError(FileSystemTestResult::kSnapshotRestore);
+      test_info.PrintResults(log);
+      current_test_suite_->TallyTimingResult(test_info);
+      continue;
+    }
+
+    // 2. Write recorded data out to block device. Theoretically, it shouldn't
+    // matter if we also "replay" the checkpoint, but skip it anyway.
+    const int write_data_res =
+      test_write_data(cow_brd_snapshot_fd, log_data.begin(), log_iter - 1);
+    if (!write_data_res) {
+      test_info.fs_test.SetError(FileSystemTestResult::kBioWrite);
+      close(cow_brd_snapshot_fd);
+      test_info.PrintResults(log);
+      current_test_suite_->TallyTimingResult(test_info);
+      continue;
+    }
+    close(cow_brd_snapshot_fd);
+
+    // 3. Check the resulting disk image with fsck and the user test. For now,
+    // just ignore the timing data that we can get from this function.
+    test_fsck_and_user_test(SNAPSHOT_PATH,
+        test_info.permute_data.last_checkpoint, test_info);
+
+    test_info.PrintResults(log);
+    current_test_suite_->TallyTimingResult(test_info);
+
+    // Increment our end pointer iterater passed the Checkpoint we just stopped
+    // at.
+    ++log_iter;
+    // Increment because this is what we use to say what disk_writes we've
+    // included and we omit Checkpoints in the random version of check.
+    ++crash_state_counter;
   }
   return SUCCESS;
 }

--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "../utils/ClassLoader.h"
@@ -81,8 +82,8 @@ class Tester {
   int test_setup();
   int test_init_values(std::string mountDir, long filesysSize);
   int test_run();
-  int test_check_permutations(const int num_rounds);
   int test_check_random_permutations(const int num_rounds, std::ofstream& log);
+  int test_check_log_replay(std::ofstream& log);
   int test_restore_log();
   int test_check_current();
 
@@ -117,6 +118,8 @@ class Tester {
   std::chrono::milliseconds get_timing_stat(time_stats timing_stat);
   void PrintTimingStats(std::ostream& os);
   void PrintTestStats(std::ostream& os);
+  void StartTestSuite();
+  void EndTestSuite();
 
   // TODO(ashmrtn): Figure out why making these private slows things down a lot.
  private:
@@ -131,6 +134,7 @@ class Tester {
   std::string device_mount;
   std::string flags_device;
 
+  TestSuiteResult *current_test_suite_ = NULL;
 
   bool wrapper_inserted = false;
   bool cow_brd_inserted = false;
@@ -149,6 +153,11 @@ class Tester {
   bool test_write_data(const int disk_fd,
       const std::vector<fs_testing::utils::disk_write>::iterator& start,
       const std::vector<fs_testing::utils::disk_write>::iterator& end);
+
+  std::pair<std::chrono::milliseconds, std::chrono::milliseconds>
+    test_fsck_and_user_test(const std::string device_path,
+                            const unsigned int last_checkpoint,
+                            SingleTestInfo &test_info);
 
   std::vector<TestSuiteResult> test_results_;
   std::chrono::milliseconds timing_stats[NUM_TIME] =

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -36,7 +36,7 @@
 #define DIRECTORY_PERMS \
   (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
 
-#define OPTS_STRING "bd:f:e:l:mn:p:r:s:t:vIP"
+#define OPTS_STRING "bd:f:e:l:m:np:r:s:t:vIP"
 
 namespace {
   unsigned int kSocketQueueDepth;

--- a/code/results/TestSuiteResult.cpp
+++ b/code/results/TestSuiteResult.cpp
@@ -13,62 +13,91 @@ using fs_testing::tests::DataTestResult;
 using fs_testing::FileSystemTestResult;
 using fs_testing::SingleTestInfo;
 
-void TestSuiteResult::TallyResult(SingleTestInfo& done) {
+void TestSuiteResult::TallyResult(SingleTestInfo &done, ResultSet &set) {
   switch (done.GetTestResult()) {
     case SingleTestInfo::kPassed:
-      ++num_passed_;
+      ++set.num_passed;
       break;
     case SingleTestInfo::kFsckFixed:
-      ++num_passed_fixed_;
+      ++set.num_passed_fixed;
       break;
     case SingleTestInfo::kFsckRequired:
-      ++fsck_required_;
+      ++set.fsck_required;
       break;
     case SingleTestInfo::kFailed:
-      ++num_failed_;
+      ++set.num_failed;
 
       switch (done.data_test.GetError()) {
         case DataTestResult::kOldFilePersisted:
-          ++old_file_persisted_;
+          ++set.old_file_persisted;
           break;
         case DataTestResult::kFileMissing:
-          ++file_missing_;
+          ++set.file_missing;
           break;
         case DataTestResult::kFileDataCorrupted:
-          ++file_data_corrupted_;
+          ++set.file_data_corrupted;
           break;
         case DataTestResult::kFileMetadataCorrupted:
-          ++file_metadata_corrupted_;
+          ++set.file_metadata_corrupted;
           break;
         case DataTestResult::kIncorrectBlockCount:
-          ++incorrect_block_count_;
+          ++set.incorrect_block_count;
           break;    
         case DataTestResult::kOther:
-          ++other_;
+          ++set.other;
           break;
       }
       break;
   }
 }
 
+void TestSuiteResult::TallyReorderingResult(SingleTestInfo &r) {
+  TallyResult(r, reordering_results_);
+}
+void TestSuiteResult::TallyTimingResult(SingleTestInfo &r) {
+  TallyResult(r, timing_results_);
+}
+
+unsigned int TestSuiteResult::GetReorderingCompleted() const {
+  return reordering_results_.num_passed + reordering_results_.num_passed_fixed +
+    reordering_results_.fsck_required + reordering_results_.num_failed;
+}
+
+unsigned int TestSuiteResult::GetTimingCompleted() const {
+  return timing_results_.num_passed + timing_results_.num_passed_fixed +
+    timing_results_.fsck_required + timing_results_.num_failed;
+}
+
 unsigned int TestSuiteResult::GetCompleted() const {
-  return num_passed_ + num_passed_fixed_ + fsck_required_ + num_failed_;
+  return GetTimingCompleted() + GetReorderingCompleted();
 }
 
 void TestSuiteResult::PrintResults(ostream& os) const {
-  os << "Ran " <<
-    num_failed_ + num_passed_fixed_ + num_passed_ + fsck_required_ <<
-    " tests with" <<
-    "\n\tpassed cleanly: " << num_passed_ <<
-    "\n\tpassed fixed: " << num_passed_fixed_ <<
-    "\n\tfsck required: " << fsck_required_ <<
-    "\n\tfailed: " << num_failed_ <<
-    "\n\t\told file persisted: " << old_file_persisted_ <<
-    "\n\t\tfile missing: " << file_missing_ <<
-    "\n\t\tfile data corrupted: " << file_data_corrupted_ <<
-    "\n\t\tfile metadata corrupted: " << file_metadata_corrupted_ <<
-    "\n\t\tincorrect block count: " << incorrect_block_count_ <<
-    "\n\t\tother: " << other_ << endl;
+  os << "Reordering tests ran " << GetReorderingCompleted() << " tests with" <<
+    "\n\tpassed cleanly: " << reordering_results_.num_passed <<
+    "\n\tpassed fixed: " << reordering_results_.num_passed_fixed <<
+    "\n\tfsck required: " << reordering_results_.fsck_required <<
+    "\n\tfailed: " << reordering_results_.num_failed <<
+    "\n\t\told file persisted: " << reordering_results_.old_file_persisted <<
+    "\n\t\tfile missing: " << reordering_results_.file_missing <<
+    "\n\t\tfile data corrupted: " << reordering_results_.file_data_corrupted <<
+    "\n\t\tfile metadata corrupted: " <<
+      reordering_results_.file_metadata_corrupted <<
+    "\n\t\tother: " << reordering_results_.other << endl << endl;
+
+  os << "Timing tests ran " << GetTimingCompleted() << " tests with" <<
+    "\n\tpassed cleanly: " << timing_results_.num_passed <<
+    "\n\tpassed fixed: " << timing_results_.num_passed_fixed <<
+    "\n\tfsck required: " << timing_results_.fsck_required <<
+    "\n\tfailed: " << timing_results_.num_failed <<
+    "\n\t\told file persisted: " << timing_results_.old_file_persisted <<
+    "\n\t\tfile missing: " << timing_results_.file_missing <<
+    "\n\t\tfile data corrupted: " << timing_results_.file_data_corrupted <<
+    "\n\t\tfile metadata corrupted: " <<
+      timing_results_.file_metadata_corrupted <<
+    "\n\t\tincorrect block count: " <<
+      timing_results_.incorrect_block_count <<
+    "\n\t\tother: " << timing_results_.other << endl << endl;
 }
 
 }  // namespace fs_testing

--- a/code/results/TestSuiteResult.h
+++ b/code/results/TestSuiteResult.h
@@ -9,26 +9,35 @@
 
 namespace fs_testing {
 
+struct ResultSet {
+  unsigned int num_failed = 0;
+  unsigned int num_passed_fixed = 0;
+  unsigned int num_passed = 0;
+  unsigned int total_tests = 0;
+
+  unsigned int fsck_required = 0;
+  unsigned int old_file_persisted = 0;
+  unsigned int file_missing = 0;
+  unsigned int file_data_corrupted = 0;
+  unsigned int file_metadata_corrupted = 0;
+  unsigned int incorrect_block_count = 0;
+  unsigned int other = 0;
+};
+
 class TestSuiteResult {
  public:
-  void TallyResult(fs_testing::SingleTestInfo& r);
+  void TallyReorderingResult(fs_testing::SingleTestInfo &r);
+  void TallyTimingResult(fs_testing::SingleTestInfo &r);
   unsigned int GetCompleted() const;
+  unsigned int GetReorderingCompleted() const;
+  unsigned int GetTimingCompleted() const;
   void PrintResults(std::ostream& os) const;
 
  private:
-  unsigned int num_failed_ = 0;
-  unsigned int num_passed_fixed_ = 0;
-  unsigned int num_passed_ = 0;
-  unsigned int total_tests_ = 0;
+  ResultSet reordering_results_;
+  ResultSet timing_results_;
 
-  unsigned int fsck_required_ = 0;
-  unsigned int old_file_persisted_ = 0;
-  unsigned int file_missing_ = 0;
-  unsigned int file_data_corrupted_ = 0;
-  unsigned int file_metadata_corrupted_ = 0;
-  unsigned int incorrect_block_count_ = 0;
-  unsigned int other_ = 0;
-
+  void TallyResult(fs_testing::SingleTestInfo &r, ResultSet &set);
 };
 
 }  // namespace fs_testing

--- a/code/tests/eof_blocks_loss.cpp
+++ b/code/tests/eof_blocks_loss.cpp
@@ -4,6 +4,7 @@
 #include <unistd.h>
 
 #include <iostream>
+#include <string>
 
 #include "BaseTestCase.h"
 #include "../user_tools/api/workload.h"
@@ -96,8 +97,11 @@ class EOFBlocksLoss: public BaseTestCase {
 
     //After fdatasync call, if you crash at any point, and on recovery
     //if blocks != 32, EOF blocks are missing.
-    if (last_checkpoint == 1 && stats.st_blocks != 32){
+    if (last_checkpoint == 2 && stats.st_blocks != 32) {
     	test_result->SetError(DataTestResult::kIncorrectBlockCount);
+      test_result->error_description =
+        "expected file to have 32 blocks but found " +
+        std::to_string(stats.st_blocks);
     	return 0;
     }
 


### PR DESCRIPTION
Create a mode in CrashMonkey (that you can turn off with a flag) that will replay the logged workload in the order it was recorded. It will stop at each checkpoint in the workload to run `fsck` and user data tests. Update README with how to run this test.