### PR TITLE
Lseek bug fix

### DIFF
--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -467,7 +467,7 @@ int Tester::test_check_random_permutations(const int num_rounds,
     ofstream& log) {
   time_point<steady_clock> start_time = steady_clock::now();
   Permuter *p = permuter_loader.get_instance();
-  p->InitDataVector(&log_data);
+  p->InitDataVector(log_data);
   vector<disk_write> permutes;
   TestSuiteResult test_suite;
   for (int rounds = 0; rounds < num_rounds; ++rounds) {

--- a/code/permuter/Permuter.cpp
+++ b/code/permuter/Permuter.cpp
@@ -1,6 +1,8 @@
 #include <list>
 #include <vector>
 
+#include <cassert>
+
 #include "Permuter.h"
 #include "../utils/utils.h"
 
@@ -8,17 +10,13 @@ namespace fs_testing {
 namespace permuter {
 
 using std::list;
+using std::pair;
 using std::size_t;
 using std::vector;
 
 using fs_testing::utils::disk_write;
 
 namespace {
-
-struct range {
-  unsigned int start;
-  unsigned int end;
-};
 
 static const unsigned int kRetryMultiplier = 2;
 static const unsigned int kMinRetries = 1000;
@@ -48,94 +46,128 @@ bool BioVectorEqual::operator() (const std::vector<unsigned int>& a,
   return true;
 }
 
-void Permuter::InitDataVector(vector<disk_write> *data) {
+/*
+ * Given a disk_write operation and a *sorted* list of already existing ranges,
+ * determine if the current operation partially or completely overlaps any of
+ * the operations already in the list.
+ *
+ * Returns false if the operation does not belong to any range.
+ * Else, returns true.
+ */
+bool Permuter::FindOverlapsAndInsert(disk_write &dw,
+    list<pair<unsigned int, unsigned int>> &ranges) const {
+
+  unsigned int start = dw.metadata.write_sector;
+  unsigned int end = start + dw.metadata.size;
+  for (auto range_iter = ranges.begin(); range_iter != ranges.end();
+      range_iter++) {
+    if ((range_iter->first <= start && range_iter->second >= start) ||
+        (range_iter->first <= end && range_iter->second >= end) ||
+        (range_iter->first >= start && range_iter->second <= end)) {
+      // We need to extend our range to cover what we are looking at.
+      if (range_iter->first > dw.metadata.write_sector) {
+        range_iter->first = dw.metadata.write_sector;
+      }
+      unsigned int end =
+        dw.metadata.write_sector + dw.metadata.size;
+      if (range_iter->second < end) {
+        range_iter->second = end;
+      }
+      return true;
+    } else if (range_iter->first > end) {
+      // We assume the list we are given is ordered. Therefore, if the next item
+      // in the list has a start that is greater than the end of the disk_write
+      // in question, we know we won't find anything else in the list this
+      // disk_write overlaps with. In this case, we should insert the
+      // disk_write in the list where we currently are.
+      ranges.insert(range_iter,
+          {dw.metadata.write_sector,
+          dw.metadata.write_sector + dw.metadata.size});
+      return false;
+    }
+  }
+
+  // We reached the end of the list of ranges without finding anything starting
+  // after the end of what we are looking at.
+  ranges.emplace_back(dw.metadata.write_sector,
+      dw.metadata.write_sector + dw.metadata.size);
+  return false;
+}
+
+void Permuter::InitDataVector(vector<disk_write> &data) {
   epochs_.clear();
-  bool prev_epoch_flush_op = false;
-  disk_write data_half;
-  list<range> overlaps;
+  list<pair<unsigned int, unsigned int>> epoch_overlaps;
+  struct epoch *current_epoch = NULL;
   // Make sure that the first time we mark a checkpoint epoch, we start at 0 and
   // not 1.
   int curr_checkpoint_epoch = -1;
   // Aligns with the index of the bio in the profile dump, 0 indexed.
   unsigned int abs_index = 0;
 
-  auto curr_op = data->begin();
-  while (curr_op != data->end()) {
-    struct epoch current_epoch;
-    current_epoch.has_barrier = false;
-    current_epoch.overlaps = false;
-    current_epoch.checkpoint_epoch = curr_checkpoint_epoch;
+  auto curr_op = data.begin();
+  while (curr_op != data.end()) {
+    if (current_epoch == NULL) {
+      epochs_.emplace_back();
+      current_epoch = &epochs_.back();
+      // Overlaps are only searched for within the current epoch, not across
+      // epochs.
+      epoch_overlaps.clear();
+      current_epoch->has_barrier = false;
+      current_epoch->overlaps = false;
+      current_epoch->checkpoint_epoch = curr_checkpoint_epoch;
+    }
 
-    // Get all ops in this epoch and add them to either the sync_op or async_op
-    // lists.
-    while (curr_op != data->end() && !curr_op->is_barrier_write()) {
+    // While the operation is not a barrier operation (flush or FUA of some
+    // sort), we should add it to the current epoch. If the operation is a
+    // barrier operation, we want to add it to the current epoch and switch
+    // epochs.
+    while (curr_op != data.end() && !curr_op->is_barrier()) {
       // Checkpoint operations will only be seen once we have switched over
       // epochs, so we need to edit the checkpoint epoch of the current epoch as
       // well as incrementing the curr_checkpoint_epoch counter.
       if (curr_op->is_checkpoint()) {
         ++curr_checkpoint_epoch;
-        current_epoch.checkpoint_epoch = curr_checkpoint_epoch;
+        current_epoch->checkpoint_epoch = curr_checkpoint_epoch;
         // Checkpoint operations should not appear in the bio stream passed to
         // actual permuters.
         ++curr_op;
         ++abs_index;
         continue;
       }
-      
-      if (prev_epoch_flush_op == true) {
-        epoch_op split_op = {abs_index, data_half};
-        // TODO(ashmrtn): Find a better way to handle matching an index to a bio
-        // in the profile dump.
-        //++abs_index;
-        current_epoch.ops.push_back(split_op);
-        current_epoch.num_meta += data_half.is_meta();
-        prev_epoch_flush_op = false;
+
+      // Check if the current operation overlaps anything we have seen already
+      // in this epoch.
+      if (FindOverlapsAndInsert(*curr_op, epoch_overlaps)) {
+        current_epoch->overlaps = true;
       }
 
-      // Find overlapping ranges.
-      unsigned int start = curr_op->metadata.write_sector;
-      unsigned int end = start + curr_op->metadata.size;
-      for (auto range_iter = overlaps.begin(); range_iter != overlaps.end();
-          range_iter++) {
-        range r = *range_iter;
-        if ((r.start <= start && r.end >= start)
-            || (r.start <= end && r.end >= end)) {
-          if (r.start > start) {
-            r.start = start;
-          }
-          if (r.end < end) {
-            r.end = end;
-          }
-          current_epoch.overlaps = true;
-          break;
-        } else if (r.start > end) {
-          // Since this is an ordered list, if the next spot is past where we're
-          // looking now then we won't find anything past here. We may as well
-          // insert an item here.
-          range new_range = {start, end};
-          overlaps.insert(range_iter, new_range);
-        }
-      }
-
-      epoch_op eo = {abs_index, *curr_op};
-      current_epoch.ops.push_back(eo);
-      current_epoch.num_meta += curr_op->is_meta();
+      current_epoch->ops.push_back({abs_index, *curr_op});
+      current_epoch->num_meta += curr_op->is_meta();
       ++abs_index;
       ++curr_op;
     }
 
     // Check is the op at the current index is a "barrier." If it is then add it
-    // to the special spot in the epoch, otherwise just push the current epoch
-    // onto the list and move to the next segment of the log.
-    if (curr_op != data->end() && curr_op->is_barrier_write()) {
-      // Check if the op at the current index has a flush flag with data. It it
-      // has, then divide it into two halves and make the data available only in
-      // the start of the next epoch. If the op has a FUA flag, then it gets
-      // normally added into the current epoch.
-      if ((curr_op->has_flush_flag() || curr_op->has_flush_seq_flag())
-          && curr_op->has_write_flag() && (!curr_op->has_FUA_flag())) {
-        disk_write flag_half;
-        data_half = *curr_op;
+    // to the end of the epoch, otherwise just push the current epoch onto the
+    // list and move to the next segment of the log. The only reasons you should
+    // get here really are 1. you reached the end of the epoch (saw a barrier)
+    // or 2. you reached the end of the recorded workload.
+    if (curr_op != data.end()) {
+      assert(curr_op->is_barrier());
+
+      // Check if the op at the current index has a flush flag with data. If it
+      // does, then divide it into an operation with the flush flag and an
+      // operation with the data where the data is available only in the start
+      // of the next epoch. This is necessary because a flush flag only
+      // stipulates the previous data is persisted, and says nothing about the
+      // data in the current operation's persistence. If the FUA flag is
+      // present, then the current data is persisted with the previous data,
+      // meaning this block does not apply.
+      if ((curr_op->has_flush_flag() || curr_op->has_flush_seq_flag()) &&
+          curr_op->has_write_flag() && !curr_op->has_FUA_flag() &&
+          curr_op->metadata.size > 0) {
+        disk_write flag_half(*curr_op);
+        disk_write data_half(*curr_op);
         
         if(curr_op->has_flush_flag()) {
           flag_half.set_flush_flag();
@@ -146,26 +178,51 @@ void Permuter::InitDataVector(vector<disk_write> *data) {
           flag_half.set_flush_seq_flag();
           data_half.clear_flush_seq_flag();
         }
-        
-        epoch_op oe = {abs_index, flag_half};
-        current_epoch.ops.push_back(oe);
-        current_epoch.num_meta += flag_half.is_meta();
-        epochs_.push_back(current_epoch);
-        prev_epoch_flush_op = true;
-        current_epoch.has_barrier = true;
+
+        flag_half.metadata.size = 0;
+        flag_half.clear_data();
+
+        // Add the flush to the current epoch.
+        current_epoch->ops.push_back({abs_index, flag_half});
+        current_epoch->num_meta += flag_half.is_meta();
+        current_epoch->has_barrier = true;
+        epochs_.push_back(*current_epoch);
+
+        // Switch epochs.
+        epochs_.emplace_back();
+        current_epoch = &epochs_.back();
+        epoch_overlaps.clear();
+        current_epoch->has_barrier = false;
+        current_epoch->overlaps = false;
+        current_epoch->checkpoint_epoch = curr_checkpoint_epoch;
+        // We are adding a new operation to the new epoch, so we need to record
+        // it in the list of things to check for overlaps.
+        epoch_overlaps.emplace_back(data_half.metadata.write_sector,
+            data_half.metadata.write_sector + data_half.metadata.size);
+
+        // Setup the rest of the data part of the operation.
+        // TODO(ashmrtn): Find a better way to handle matching an index to a bio
+        // in the profile dump.
+        //++abs_index;
+        current_epoch->ops.push_back({abs_index, data_half});
+        current_epoch->num_meta += data_half.is_meta();
+
         ++abs_index;
         ++curr_op;
-        continue;
-      }
+      } else {
+        // This is just the case where we have a normal barrier operation ending
+        // the epoch.
+        current_epoch->ops.push_back({abs_index, *curr_op});
+        current_epoch->num_meta += curr_op->is_meta();
+        current_epoch->has_barrier = true;
+        ++abs_index;
+        ++curr_op;
 
-      epoch_op oe = {abs_index, *curr_op};
-      current_epoch.ops.push_back(oe);
-      current_epoch.num_meta += curr_op->is_meta();
-      current_epoch.has_barrier = true;
-      ++abs_index;
-      ++curr_op;
+        // This will cause us to create a new epoch at the end of our vector on
+        // the next loop.
+        current_epoch = NULL;
+      }
     }
-    epochs_.push_back(current_epoch);
   }
 }
 

--- a/code/permuter/Permuter.h
+++ b/code/permuter/Permuter.h
@@ -1,7 +1,9 @@
 #ifndef PERMUTER_H
 #define PERMUTER_H
 
+#include <list>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "../utils/utils.h"
@@ -38,7 +40,7 @@ struct epoch {
 class Permuter {
  public:
   virtual ~Permuter() {};
-  void InitDataVector(std::vector<fs_testing::utils::disk_write>* data);
+  void InitDataVector(std::vector<fs_testing::utils::disk_write> &data);
   bool GenerateCrashState(std::vector<fs_testing::utils::disk_write>& res,
       PermuteTestResult &log_data);
 
@@ -49,6 +51,8 @@ class Permuter {
   virtual void init_data(std::vector<epoch> *data) = 0;
   virtual bool gen_one_state(std::vector<epoch_op>& res,
       PermuteTestResult &log_data) = 0;
+  bool FindOverlapsAndInsert(fs_testing::utils::disk_write &dw,
+      std::list<std::pair<unsigned int, unsigned int>> &ranges) const;
 
   std::vector<epoch> epochs_;
   std::unordered_set<std::vector<unsigned int>, BioVectorHash, BioVectorEqual>

--- a/code/utils/utils.cpp
+++ b/code/utils/utils.cpp
@@ -45,8 +45,8 @@ bool disk_write::is_async_write() {
   return c_is_async_write(&metadata);
 }
 
-bool disk_write::is_barrier_write() {
-  return c_is_barrier_write(&metadata);
+bool disk_write::is_barrier() {
+  return c_is_barrier(&metadata);
 }
 
 bool disk_write::is_meta() {

--- a/code/utils/utils.h
+++ b/code/utils/utils.h
@@ -23,7 +23,7 @@ class disk_write {
   friend bool operator!=(const disk_write& a, const disk_write& b);
 
   bool has_write_flag();
-  bool is_barrier_write();
+  bool is_barrier();
   bool is_async_write();
   bool is_checkpoint();
   bool is_meta();

--- a/code/utils/utils.h
+++ b/code/utils/utils.h
@@ -14,13 +14,11 @@ namespace utils {
 
 class disk_write {
  public:
-  disk_write() = default;
+  disk_write();
   disk_write(const struct disk_write_op_meta& m, const char *d);
-  disk_write(const disk_write& other);
 
   struct disk_write_op_meta metadata;
 
-  void operator=(const disk_write& other);
   friend bool operator==(const disk_write& a, const disk_write& b);
   friend bool operator!=(const disk_write& a, const disk_write& b);
 
@@ -51,6 +49,7 @@ class disk_write {
   // Pointer is valid only as long as the object exists or otherwise attempt
   // memory management of it.
   std::shared_ptr<char> get_data();
+  void clear_data();
 
  private:
   std::shared_ptr<char> data;

--- a/code/utils/utils_c.c
+++ b/code/utils/utils_c.c
@@ -43,12 +43,11 @@ bool c_is_async_write(struct disk_write_op_meta *m) {
             (m->bi_rw & REQ_WRITE);
 }
 
-bool c_is_barrier_write(struct disk_write_op_meta *m) {
-  return ((m->bi_rw & REQ_FUA) ||
+bool c_is_barrier(struct disk_write_op_meta *m) {
+  return (m->bi_rw & REQ_FUA) ||
           (m->bi_rw & REQ_FLUSH) ||
           (m->bi_rw & REQ_FLUSH_SEQ) ||
-          (m->bi_rw & REQ_SOFTBARRIER)) &&
-          (m->bi_rw & REQ_WRITE);
+          (m->bi_rw & REQ_SOFTBARRIER);
 }
 
 bool c_is_meta(struct disk_write_op_meta *m) {

--- a/code/utils/utils_c.h
+++ b/code/utils/utils_c.h
@@ -15,7 +15,7 @@ extern "C"
 #include "../disk_wrapper_ioctl.h"
 
 bool c_is_async_write(struct disk_write_op_meta *m);
-bool c_is_barrier_write(struct disk_write_op_meta *m);
+bool c_is_barrier(struct disk_write_op_meta *m);
 bool c_is_meta(struct disk_write_op_meta *m);
 bool c_is_checkpoint(struct disk_write_op_meta *m);
 bool c_has_write_flag(struct disk_write_op_meta *m);


### PR DESCRIPTION
`lseek` was failing due to an initialization bug in Permuter::InitDataVector. This patch refactors the code in that method to try to make things clearer and to fix the bug.

Given that this was not an obvious bug and this code is somewhat complicated it seems like we should have some unit tests to make sure things are working right. Should I make some tests for this?