### PR TITLE
Port CrashMonkey kernel modules to kernel 4.15

### DIFF
--- a/code/bio_alias.h
+++ b/code/bio_alias.h
@@ -10,19 +10,42 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) \
   && LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)
 
+#define BI_RW                   bi_rw
+#define BI_DISK                 bi_bdev->bi_disk
 #define BI_SIZE                 bi_size
 #define BI_SECTOR               bi_sector
 #define BIO_ENDIO(bio, err)     bio_endio(bio, err)
+#define BIO_IO_ERR(bio, err)    bio_endio(bio, err)
+#define BIO_DISCARD_FLAG        REQ_DISCARD
+#define BIO_IS_WRITE(bio)       (!!(bio_rw(bio) & REQ_WRITE))
 
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) \
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0) \
   && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
 
+#define BI_RW                   bi_rw
+#define BI_DISK                 bi_bdev->bi_disk
 #define BI_SIZE                 bi_iter.bi_size
 #define BI_SECTOR               bi_iter.bi_sector
-#define BIO_ENDIO(bio, err)     bio->bi_error = err; bio_endio(bio)
+#define BIO_ENDIO(bio, err)     bio_endio(bio)
+#define BIO_IO_ERR(bio, err)    bio_io_error(bio)
+#define BIO_DISCARD_FLAG        REQ_DISCARD
+#define BIO_IS_WRITE(bio)       (!!(bio_rw(bio) & REQ_WRITE))
+
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) \
+  && LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+
+#define BI_RW                   bi_opf
+#define BI_DISK                 bi_disk
+#define BI_SIZE                 bi_iter.bi_size
+#define BI_SECTOR               bi_iter.bi_sector
+#define BIO_ENDIO(bio, err)     bio_endio(bio)
+#define BIO_IO_ERR(bio, err)    bio_io_error(bio)
+#define BIO_DISCARD_FLAG        REQ_OP_DISCARD
+#define BIO_IS_WRITE(bio)       op_is_write(bio_op(bio))
 
 #else
-#error "Unsupported kernel version: crashmonkey has not been tested with your kernel version."
+#error "Unsupported kernel version: CrashMonkey has not been tested with " \
+  "your kernel version."
 #endif
 
 #endif //CRASHMONKEY_BIO_ALIAS_H

--- a/code/bio_alias.h
+++ b/code/bio_alias.h
@@ -11,7 +11,7 @@
   && LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)
 
 #define BI_RW                   bi_rw
-#define BI_DISK                 bi_bdev->bi_disk
+#define BI_DISK                 bi_bdev->bd_disk
 #define BI_SIZE                 bi_size
 #define BI_SECTOR               bi_sector
 #define BIO_ENDIO(bio, err)     bio_endio(bio, err)
@@ -23,7 +23,7 @@
   && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
 
 #define BI_RW                   bi_rw
-#define BI_DISK                 bi_bdev->bi_disk
+#define BI_DISK                 bi_bdev->bd_disk
 #define BI_SIZE                 bi_iter.bi_size
 #define BI_SECTOR               bi_iter.bi_sector
 #define BIO_ENDIO(bio, err)     bio_endio(bio)

--- a/code/cow_brd.c
+++ b/code/cow_brd.c
@@ -347,20 +347,20 @@ static void copy_from_brd(void *dst, struct brd_device *brd, sector_t sector,
  * Process a single bvec of a bio.
  */
 static int brd_do_bvec(struct brd_device *brd, struct page *page,
-      unsigned int len, unsigned int off, int rw,
+      unsigned int len, unsigned int off, bool is_write,
       sector_t sector)
 {
   void *mem;
   int err = 0;
 
-  if (rw != READ) {
+  if (is_write) {
     err = copy_to_brd_setup(brd, sector, len);
     if (err)
       goto out;
   }
 
   mem = kmap_atomic(page);
-  if (rw == READ) {
+  if (!is_write) {
     copy_from_brd(mem + off, brd, sector, len);
     flush_dcache_page(page);
   } else {
@@ -373,39 +373,39 @@ out:
   return err;
 }
 
-static void brd_make_request(struct request_queue *q, struct bio *bio)
-{
-  struct block_device *bdev = bio->bi_bdev;
-  struct brd_device *brd = bdev->bd_disk->private_data;
-  int rw;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+static void brd_make_request(struct request_queue *q, struct bio *bio) {
+#else
+static blk_qc_t brd_make_request(struct request_queue *q, struct bio *bio) {
+#endif
+  struct brd_device *brd = bio->BI_DISK->private_data;
+  bool rw;
   sector_t sector;
   int err = -EIO;
 
   sector = bio->BI_SECTOR;
-  if (bio_end_sector(bio) > get_capacity(bdev->bd_disk)) {
+  if (bio_end_sector(bio) > get_capacity(bio->BI_DISK)) {
     printk(KERN_INFO DEVICE_NAME ": cow_brd%d past end of disk, EIO\n",
         brd->brd_number);
-    goto out;
+    goto out_err;
   }
 
-  if ((bio->bi_rw & WRITE || bio->bi_rw & REQ_DISCARD) && !brd->is_writable) {
+  if ((bio->BI_RW & WRITE || bio->BI_RW & BIO_DISCARD_FLAG) &&
+      !brd->is_writable) {
     printk(KERN_INFO DEVICE_NAME ": cow_brd%d not writable, EIO\n",
         brd->brd_number);
-    goto out;
+    goto out_err;
   }
 
-  if (unlikely(bio->bi_rw & REQ_DISCARD)) {
+  if (unlikely(bio->BI_RW & BIO_DISCARD_FLAG)) {
     err = 0;
     discard_from_brd(brd, sector, bio->BI_SIZE);
     goto out;
   }
 
-  rw = bio_rw(bio);
-  if (rw == READA) {
-    rw = READ;
-  }
+  rw = BIO_IS_WRITE(bio);
 
-  #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)
   struct bio_vec *bvec;
   int iter;
   bio_for_each_segment(bvec, bio, iter) {
@@ -413,11 +413,11 @@ static void brd_make_request(struct request_queue *q, struct bio *bio)
     err = brd_do_bvec(brd, bvec->bv_page, len,
           bvec->bv_offset, rw, sector);
     if (err) {
-      break;
+      goto out_err;
     }
     sector += len >> SECTOR_SHIFT;
   }
-  #else
+#else
   struct bio_vec bvec;
   struct bvec_iter iter;
   bio_for_each_segment(bvec, bio, iter) {
@@ -425,14 +425,24 @@ static void brd_make_request(struct request_queue *q, struct bio *bio)
     err = brd_do_bvec(brd, bvec.bv_page, len,
           bvec.bv_offset, rw, sector);
     if (err) {
-      break;
+      goto out_err;
     }
     sector += len >> SECTOR_SHIFT;
   }
-  #endif
+#endif
 
 out:
   BIO_ENDIO(bio, err);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+  return;
+#else
+  return BLK_QC_T_NONE;
+#endif
+out_err:
+  BIO_IO_ERR(bio, err);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+  return BLK_QC_T_NONE;
+#endif
 }
 
 #ifdef CONFIG_BLK_DEV_XIP
@@ -463,7 +473,6 @@ static int brd_ioctl(struct block_device *bdev, fmode_t mode,
 {
   int error = 0;
   struct brd_device *brd = bdev->bd_disk->private_data;
-  struct brd_device *snapshots;
 
   switch (cmd) {
     case COW_BRD_SNAPSHOT:
@@ -570,7 +579,9 @@ static struct brd_device *brd_alloc(int i)
 
   brd->brd_queue->limits.discard_granularity = PAGE_SIZE;
   brd->brd_queue->limits.max_discard_sectors = UINT_MAX;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 12, 0)
   brd->brd_queue->limits.discard_zeroes_data = 1;
+#endif
   queue_flag_set_unlocked(QUEUE_FLAG_DISCARD, brd->brd_queue);
 
   disk = brd->brd_disk = alloc_disk(1 << part_shift);

--- a/code/disk_wrapper.c
+++ b/code/disk_wrapper.c
@@ -336,19 +336,19 @@ static unsigned long long convert_flags(unsigned long long flags) {
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) \
     && LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
 
-  if (flags & REQ_OP_WRITE) {
+  if ((flags & REQ_OP_MASK) == REQ_OP_WRITE) {
     res |= HWM_WRITE_FLAG;
   }
-  if (flags & REQ_OP_DISCARD) {
+  if ((flags & REQ_OP_MASK) == REQ_OP_DISCARD) {
     res |= HWM_DISCARD_FLAG;
   }
-  if (flags & REQ_OP_SECURE_ERASE) {
+  if ((flags & REQ_OP_MASK) == REQ_OP_SECURE_ERASE) {
     res |= HWM_SECURE_FLAG;
   }
-  if (flags & REQ_OP_WRITE_SAME) {
+  if ((flags & REQ_OP_MASK) == REQ_OP_WRITE_SAME) {
     res |= HWM_WRITE_SAME_FLAG;
   }
-  if (flags & REQ_OP_WRITE_ZEROES) {
+  if ((flags & REQ_OP_MASK) == REQ_OP_WRITE_ZEROES) {
     res |= HWM_WRITE_ZEROES_FLAG;
   }
 
@@ -388,6 +388,7 @@ static unsigned long long convert_flags(unsigned long long flags) {
   if (flags & REQ_RAHEAD) {
     res |= HWM_READAHEAD_FLAG;
   }
+
 #else
 #error "Unsupported kernel version: CrashMonkey has not been tested with " \
   "your kernel version."
@@ -635,6 +636,7 @@ static int __init disk_wrapper_init(void) {
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
   Device.target_dev = target_device->bd_disk;
   Device.target_partno = target_device->bd_partno;
+  Device.target_bd = target_device;
 #else
 #error "Unsupported kernel version: CrashMonkey has not been tested with " \
   "your kernel version."

--- a/code/disk_wrapper.c
+++ b/code/disk_wrapper.c
@@ -48,7 +48,20 @@ static struct hwm_device {
   u8* data;
   struct gendisk* gd;
   bool log_on;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) && \
+  LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   struct block_device* target_dev;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+   LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+  struct gendisk* target_dev;
+  u8 target_partno;
+  struct block_device* target_bd;
+#else
+#error "Unsupported kernel version: CrashMonkey has not been tested with " \
+  "your kernel version."
+#endif
   // Pointer to first write op in the chain.
   struct disk_write_op* writes;
   // Pointer to last write op in the chain.
@@ -57,6 +70,8 @@ static struct hwm_device {
   struct disk_write_op* current_log_write;
   unsigned long current_checkpoint;
 } Device;
+
+static bool should_log(struct bio *bio);
 
 static void free_logs(void) {
   // Remove all writes.
@@ -197,10 +212,13 @@ static const struct block_device_operations disk_wrapper_ops = {
 
 /*
  * Converts from kernel specific flags to flags that CrashMonkey uses.
+ * Frustratingly, Linux switch to a completely differnt set of flags between 4.4
+ * and 4.15.
  */
 static unsigned long long convert_flags(unsigned long long flags) {
   unsigned long long res = 0;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
   // These flags are in both 3.13 and 4.4.
   if (flags & REQ_WRITE) {
     res |= HWM_WRITE_FLAG;
@@ -315,10 +333,96 @@ static unsigned long long convert_flags(unsigned long long flags) {
     res |= HWM_NO_TIMEOUT_FLAG;
   }
 #endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) \
+    && LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+
+  if (flags & REQ_OP_WRITE) {
+    res |= HWM_WRITE_FLAG;
+  }
+  if (flags & REQ_OP_DISCARD) {
+    res |= HWM_DISCARD_FLAG;
+  }
+  if (flags & REQ_OP_SECURE_ERASE) {
+    res |= HWM_SECURE_FLAG;
+  }
+  if (flags & REQ_OP_WRITE_SAME) {
+    res |= HWM_WRITE_SAME_FLAG;
+  }
+  if (flags & REQ_OP_WRITE_ZEROES) {
+    res |= HWM_WRITE_ZEROES_FLAG;
+  }
+
+  if (flags & REQ_FAILFAST_DEV) {
+    res |= HWM_FAILFAST_DEV_FLAG;
+  }
+  if (flags & REQ_FAILFAST_TRANSPORT) {
+    res |= HWM_FAILFAST_TRANSPORT_FLAG;
+  }
+  if (flags & REQ_FAILFAST_DRIVER) {
+    res |= HWM_FAILFAST_DRIVER_FLAG;
+  }
+  if (flags & REQ_SYNC) {
+    res |= HWM_SYNC_FLAG;
+  }
+  if (flags & REQ_META) {
+    res |= HWM_META_FLAG;
+  }
+  if (flags & REQ_PRIO) {
+    res |= HWM_PRIO_FLAG;
+  }
+  if (flags & REQ_NOMERGE) {
+    res |= HWM_NOMERGE_FLAG;
+  }
+  if (!(flags & REQ_IDLE)) {
+    res |= HWM_NOIDLE_FLAG;
+  }
+  if (flags & REQ_INTEGRITY) {
+    res |= HWM_INTEGRITY_FLAG;
+  }
+  if (flags & REQ_FUA) {
+    res |= HWM_FUA_FLAG;
+  }
+  if (flags & REQ_PREFLUSH) {
+    res |= HWM_FLUSH_FLAG;
+  }
+  if (flags & REQ_RAHEAD) {
+    res |= HWM_READAHEAD_FLAG;
+  }
+#else
+#error "Unsupported kernel version: CrashMonkey has not been tested with " \
+  "your kernel version."
+#endif
   return res;
 }
 
+static bool should_log(struct bio *bio) {
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4, 4, 0)
+  return
+    (bio->BI_RW & REQ_FLUSH || bio->BI_RW & REQ_FUA ||
+     bio->BI_RW & REQ_FLUSH_SEQ || bio->BI_RW & REQ_WRITE ||
+     bio->BI_RW & REQ_DISCARD);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) \
+    && LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+  // Other REQ_OP_xx functions are odd numbers, meaning they set the
+  // REQ_OP_WRITE bit which we already check for (ex. REQ_OP_WRITE_SAME = 7).
+  return
+    ((bio->BI_RW & REQ_FUA) || (bio->BI_RW & REQ_PREFLUSH) ||
+     (bio->BI_RW & REQ_OP_FLUSH) || (bio->BI_RW & REQ_OP_WRITE) ||
+     (bio->BI_RW & BIO_DISCARD_FLAG));
+#else
+#error "Unsupported kernel version: CrashMonkey has not been tested with " \
+  "your kernel version."
+#endif
+}
+
+/*
+ * Debug output to dmesg to see what is happening. Only tested on 3.13 and 4.4
+ * kernels (and mostly accurrate on 4.4). Only enabled for <= 4.4 kernels
+ * because I'm too lazy to do all the flag translations for this in 4.15. See
+ * the output log of a workload for the textual values CrashMonkey spits out.
+ */
 static void print_rw_flags(unsigned long rw, unsigned long flags) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
   int i;
   printk(KERN_INFO "\traw rw flags: 0x%.8lx\n", rw);
   for (i = __REQ_WRITE; i < __REQ_NR_BITS; i++) {
@@ -332,10 +436,22 @@ static void print_rw_flags(unsigned long rw, unsigned long flags) {
       printk(KERN_INFO "\t%s\n", flag_names[i]);
     }
   }
+#endif
 }
 
 // TODO(ashmrtn): Currently not thread safe/reentrant. Make it so.
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+     LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
 static void disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+static blk_qc_t disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
+#else
+#error "Unsupported kernel version: CrashMonkey has not been tested with " \
+  "your kernel version."
+#endif
   int copied_data;
   struct disk_write_op *write;
   struct hwm_device* hwm;
@@ -344,116 +460,117 @@ static void disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
   /*
   printk(KERN_INFO "hwm: bio rw of size %u headed for 0x%lx (sector 0x%lx)"
       " has flags:\n", bio->BI_SIZE, bio->BI_SECTOR * 512, bio->BI_SECTOR);
-  print_rw_flags(bio->bi_rw, bio->bi_flags);
+  print_rw_flags(bio->BI_RW, bio->bi_flags);
   */
   // Log information about writes, fua, and flush/flush_seq events in kernel
   // memory.
-  if (Device.log_on) {
-    /*
-    if (bio->bi_rw & REQ_FLUSH ||
-        bio->bi_rw & REQ_FUA || bio->bi_rw & REQ_FLUSH_SEQ ||
-        bio->bi_rw & REQ_WRITE || bio->bi_rw & REQ_DISCARD ||
-        bio->bi_flags & REQ_FLUSH || bio->bi_flags & REQ_FUA ||
-        bio->bi_flags & REQ_WRITE) {
-    */
-    if (bio->bi_rw & REQ_FLUSH ||
-        bio->bi_rw & REQ_FUA || bio->bi_rw & REQ_FLUSH_SEQ ||
-        bio->bi_rw & REQ_WRITE || bio->bi_rw & REQ_DISCARD) {
-      curr_time = ktime_get();
+  if (Device.log_on && should_log(bio)) {
+    curr_time = ktime_get();
 
+    printk(KERN_INFO "hwm: bio rw of size %u headed for 0x%lx (sector 0x%lx)"
+                     " has flags:\n", bio->BI_SIZE, bio->BI_SECTOR * 512,
+           bio->BI_SECTOR);
+    print_rw_flags(bio->BI_RW, bio->bi_flags);
 
-      //printk(KERN_INFO "hwm: logging above bio\n");
-      printk(KERN_INFO "hwm: bio rw of size %u headed for 0x%lx (sector 0x%lx)"
-                       " has flags:\n", bio->BI_SIZE, bio->BI_SECTOR * 512,
-             bio->BI_SECTOR);
-      print_rw_flags(bio->bi_rw, bio->bi_flags);
-
-      // Log data to disk logs.
-      write = kzalloc(sizeof(struct disk_write_op), GFP_NOIO);
-      if (write == NULL) {
-        printk(KERN_WARNING "hwm: unable to make new write node\n");
-        goto passthrough;
-      }
-
-      write->metadata.bi_flags = convert_flags(bio->bi_flags);
-      write->metadata.bi_rw = convert_flags(bio->bi_rw);
-      write->metadata.write_sector = bio->BI_SECTOR;
-      write->metadata.size = bio->BI_SIZE;
-      write->metadata.time_ns = ktime_to_ns(curr_time);
-
-      // Protect playing around with our list of logged bios.
-      spin_lock(&Device.lock);
-      if (Device.current_write == NULL) {
-        // With the default first checkpoint, this case should never happen.
-        printk(KERN_WARNING "hwm: found empty list of previous disk ops\n");
-
-        // This is the first write in the log.
-        Device.writes = write;
-        // Set the first write in the log so that it's picked up later.
-        Device.current_log_write = write;
-      } else {
-        // Some write(s) was/were already made so add this to the back of the
-        // chain and update pointers.
-        Device.current_write->next = write;
-      }
-      Device.current_write = write;
-      spin_unlock(&Device.lock);
-
-      write->data = kmalloc(write->metadata.size, GFP_NOIO);
-      if (write->data == NULL) {
-        printk(KERN_WARNING "hwm: unable to get memory for data logging\n");
-        kfree(write);
-        goto passthrough;
-      }
-      copied_data = 0;
-
-      #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0)
-      struct bio_vec *vec;
-      int iter;
-      bio_for_each_segment(vec, bio, iter) {
-        //printk(KERN_INFO "hwm: making new page for segment of data\n");
-
-        void *bio_data = kmap(vec->bv_page);
-        memcpy((void*) (write->data + copied_data), bio_data + vec->bv_offset,
-               vec->bv_len);
-        kunmap(bio_data);
-        copied_data += vec->bv_len;
-      }
-      #else
-      struct bio_vec vec;
-      struct bvec_iter iter;
-      bio_for_each_segment(vec, bio, iter) {
-        //printk(KERN_INFO "hwm: making new page for segment of data\n");
-
-        void *bio_data = kmap(vec.bv_page);
-        memcpy((void*) (write->data + copied_data), bio_data + vec.bv_offset,
-               vec.bv_len);
-        kunmap(bio_data);
-        copied_data += vec.bv_len;
-      }
-      #endif
-      // Sanity check which prints data copied to the log.
-      /*
-      printk(KERN_INFO "hwm: copied %ld bytes of from %lx data:"
-          "\n~~~\n%s\n~~~\n",
-          write->metadata.size, write->metadata.write_sector * 512,
-          write->data);
-      */
+    // Log data to disk logs.
+    write = kzalloc(sizeof(struct disk_write_op), GFP_NOIO);
+    if (write == NULL) {
+      printk(KERN_WARNING "hwm: unable to make new write node\n");
+      goto passthrough;
     }
+
+    write->metadata.bi_flags = convert_flags(bio->bi_flags);
+    write->metadata.bi_rw = convert_flags(bio->BI_RW);
+    write->metadata.write_sector = bio->BI_SECTOR;
+    write->metadata.size = bio->BI_SIZE;
+    write->metadata.time_ns = ktime_to_ns(curr_time);
+
+    // Protect playing around with our list of logged bios.
+    spin_lock(&Device.lock);
+    if (Device.current_write == NULL) {
+      // With the default first checkpoint, this case should never happen.
+      printk(KERN_WARNING "hwm: found empty list of previous disk ops\n");
+
+      // This is the first write in the log.
+      Device.writes = write;
+      // Set the first write in the log so that it's picked up later.
+      Device.current_log_write = write;
+    } else {
+      // Some write(s) was/were already made so add this to the back of the
+      // chain and update pointers.
+      Device.current_write->next = write;
+    }
+    Device.current_write = write;
+    spin_unlock(&Device.lock);
+
+    write->data = kmalloc(write->metadata.size, GFP_NOIO);
+    if (write->data == NULL) {
+      printk(KERN_WARNING "hwm: unable to get memory for data logging\n");
+      kfree(write);
+      goto passthrough;
+    }
+    copied_data = 0;
+
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0)
+    struct bio_vec *vec;
+    int iter;
+    bio_for_each_segment(vec, bio, iter) {
+      //printk(KERN_INFO "hwm: making new page for segment of data\n");
+
+      void *bio_data = kmap(vec->bv_page);
+      memcpy((void*) (write->data + copied_data), bio_data + vec->bv_offset,
+             vec->bv_len);
+      kunmap(bio_data);
+      copied_data += vec->bv_len;
+    }
+    #else
+    struct bio_vec vec;
+    struct bvec_iter iter;
+    bio_for_each_segment(vec, bio, iter) {
+      //printk(KERN_INFO "hwm: making new page for segment of data\n");
+
+      void *bio_data = kmap(vec.bv_page);
+      memcpy((void*) (write->data + copied_data), bio_data + vec.bv_offset,
+             vec.bv_len);
+      kunmap(bio_data);
+      copied_data += vec.bv_len;
+    }
+    #endif
+    // Sanity check which prints data copied to the log.
+    /*
+    printk(KERN_INFO "hwm: copied %ld bytes of from %lx data:"
+        "\n~~~\n%s\n~~~\n",
+        write->metadata.size, write->metadata.write_sector * 512,
+        write->data);
+    */
   }
 
  passthrough:
   // Pass request off to normal device driver.
   hwm = (struct hwm_device*) q->queuedata;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   bio->bi_bdev = hwm->target_dev;
-  submit_bio(bio->bi_rw, bio);
+  submit_bio(bio->BI_RW, bio);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+  bio->bi_disk = hwm->target_dev;
+  bio->bi_partno = hwm->target_partno;
+  submit_bio(bio);
+  return BLK_QC_T_NONE;
+#else
+#error "Unsupported kernel version: CrashMonkey has not been tested with " \
+  "your kernel version."
+#endif
 }
 
 // TODO(ashmrtn): Fix error when wrong device path is passed.
 static int __init disk_wrapper_init(void) {
   unsigned int flush_flags;
   unsigned long queue_flags;
-  struct block_device *flags_device;
+  struct block_device *flags_device, *target_device;
   struct disk_write_op *first = NULL;
   ktime_t curr_time;
   printk(KERN_INFO "hwm: Hello World from module\n");
@@ -493,21 +610,35 @@ static int __init disk_wrapper_init(void) {
     goto out;
   }
 
-  Device.target_dev = blkdev_get_by_path(target_device_path,
+  target_device = blkdev_get_by_path(target_device_path,
       FMODE_READ, &Device);
-  if (!Device.target_dev || IS_ERR(Device.target_dev)) {
+  if (!target_device || IS_ERR(target_device)) {
     printk(KERN_WARNING "hwm: unable to grab underlying device\n");
     goto out;
   }
-  if (!Device.target_dev->bd_queue) {
+  if (!target_device->bd_queue) {
     printk(KERN_WARNING "hwm: attempt to wrap device with no request queue\n");
     goto out;
   }
-  if (!Device.target_dev->bd_queue->make_request_fn) {
+  if (!target_device->bd_queue->make_request_fn) {
     printk(KERN_WARNING "hwm: attempt to wrap device with no "
         "make_request_fn\n");
     goto out;
   }
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+  Device.target_dev = target_device;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+  Device.target_dev = target_device->bd_disk;
+  Device.target_partno = target_device->bd_partno;
+#else
+#error "Unsupported kernel version: CrashMonkey has not been tested with " \
+  "your kernel version."
+#endif
 
   // Get the device we should copy flags from and copy those flags into locals.
   flags_device = blkdev_get_by_path(flags_device_path, FMODE_READ, &Device);
@@ -519,7 +650,13 @@ static int __init disk_wrapper_init(void) {
     printk(KERN_WARNING "hwm: attempt to wrap device with no request queue\n");
     goto out;
   }
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+  // Field not present in kernel 4.15+.
   flush_flags = flags_device->bd_queue->flush_flags;
+#endif
   queue_flags = flags_device->bd_queue->queue_flags;
   blkdev_put(flags_device, FMODE_READ);
 
@@ -534,9 +671,9 @@ static int __init disk_wrapper_init(void) {
 
   Device.gd->private_data = &Device;
   Device.gd->major = major_num;
-  Device.gd->first_minor = Device.target_dev->bd_disk->first_minor;
-  Device.gd->minors = Device.target_dev->bd_disk->minors;
-  set_capacity(Device.gd, get_capacity(Device.target_dev->bd_disk));
+  Device.gd->first_minor = target_device->bd_disk->first_minor;
+  Device.gd->minors = target_device->bd_disk->minors;
+  set_capacity(Device.gd, get_capacity(target_device->bd_disk));
   strcpy(Device.gd->disk_name, "hwm");
   Device.gd->fops = &disk_wrapper_ops;
 
@@ -547,12 +684,23 @@ static int __init disk_wrapper_init(void) {
   }
   blk_queue_make_request(Device.gd->queue, disk_wrapper_bio);
   // Make this queue have the same flags as the queue we're feeding into.
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   Device.gd->queue->flush_flags = flush_flags;
+#endif
   Device.gd->queue->queue_flags = queue_flags;
   Device.gd->queue->queuedata = &Device;
-  printk(KERN_INFO "hwm: working with queue with:\n\tflush flags: 0x%x\n\tflags"
-      " 0x%lx\n", Device.gd->queue->flush_flags, Device.gd->queue->queue_flags);
-  //blk_queue_hardsect_size(Queue, hardsect_size);
+  printk(KERN_INFO "hwm: working with queue with:\n\tflags 0x%lx\n",
+      Device.gd->queue->queue_flags);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+  printk(KERN_INFO "hwm: working with queue with:\n\tflush flags 0x%lx\n",
+      Device.gd->queue->flush_flags);
+#endif
 
   add_disk(Device.gd);
 
@@ -566,7 +714,18 @@ static int __init disk_wrapper_init(void) {
 
 static void __exit hello_cleanup(void) {
   free_logs();
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) && \
+  LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   blkdev_put(Device.target_dev, FMODE_READ);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+  LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+  blkdev_put(Device.target_bd, FMODE_READ);
+#else
+#error "Unsupported kernel version: CrashMonkey has not been tested with " \
+  "your kernel version."
+#endif
   blk_cleanup_queue(Device.gd->queue);
   del_gendisk(Device.gd);
   put_disk(Device.gd);

--- a/code/disk_wrapper.c
+++ b/code/disk_wrapper.c
@@ -397,7 +397,7 @@ static unsigned long long convert_flags(unsigned long long flags) {
 }
 
 static bool should_log(struct bio *bio) {
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
   return
     (bio->BI_RW & REQ_FLUSH || bio->BI_RW & REQ_FUA ||
      bio->BI_RW & REQ_FLUSH_SEQ || bio->BI_RW & REQ_WRITE ||

--- a/code/disk_wrapper_ioctl.h
+++ b/code/disk_wrapper_ioctl.h
@@ -70,7 +70,11 @@ enum flag_shifts {
   REQ_HASHED_,              // On IO scheduler merge hash.
   REQ_MQ_INFLIGHT_,         // Track inflgiht for MQ (multi-queue?).
   REQ_NO_TIMEOUT_,          // Requests never expire.
-  REQ_NR_BITS_,
+
+  REQ_OP_WRITE_ZEROES_,     // Write the zero filled sector many times (4.15+).
+
+  REQ_NR_BITS_,             // No longer accurate according to the number of
+                            // bits the kernel uses.
 };
 
 #define HWM_WRITE_FLAG (1ULL << REQ_WRITE_)
@@ -84,7 +88,7 @@ enum flag_shifts {
 #define HWM_DISCARD_FLAG (1ULL << REQ_DISCARD_)
 
 #define HWM_SECURE_FLAG (1ULL << REQ_SECURE_)
-#define HWM_WRITE_SAME_FLAG (1ULL << REQ_WRITE_SAME)
+#define HWM_WRITE_SAME_FLAG (1ULL << REQ_WRITE_SAME_)
 #define HWM_NOIDLE_FLAG (1ULL << REQ_NOIDLE_)
 #define HWM_INTEGRITY_FLAG (1ULL << REQ_INTEGRITY_)
 
@@ -116,6 +120,9 @@ enum flag_shifts {
 #define HWM_HASHED_FLAG (1ULL << REQ_HASHED_)
 #define HWM_MQ_INFLIGHT_FLAG (1ULL << REQ_MQ_INFLIGHT_)
 #define HWM_NO_TIMEOUT_FLAG (1ULL << REQ_NO_TIMEOUT_)
+
+// Kernel 4.15+.
+#define HWM_WRITE_ZEROES_FLAG (1ULL << REQ_OP_WRITE_ZEROES_)
 
 #define HWM_CHECKPOINT_FLAG       (1ULL << 63)
 

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -316,6 +316,7 @@ int Tester::get_wrapper_log() {
           break;
         } else if (errno == EFAULT) {
           cerr << "efault occurred\n";
+          delete[] data;
           log_data.clear();
           return WRAPPER_MEM_ERR;
         }
@@ -1088,7 +1089,9 @@ void Tester::log_disk_write_data(std::ostream &log) {
     "time" << " " << std::setw(18) << "sector" << " " << std::setw(18) <<
     "size" << std::endl;
   for (unsigned int i = 0; i < log_data.size(); ++i) {
-    log << std::setw(5) << i << ' ' << log_data[i];
+    std::cout << "logging data at address " << std::hex << &log_data.at(i) <<
+      std::dec << std::endl;
+    log << std::setw(5) << i << ' ' << log_data.at(i);
   }
   log.precision(digits);
   log.flags(fflags);

--- a/code/utils/utils.cpp
+++ b/code/utils/utils.cpp
@@ -43,7 +43,7 @@ static const char* const flag_names[] = {
   "flush", "read ahead", "throttled", "sorted", "soft barrier", "no merge",
   "started", "don't prep", "queued", "elv priv", "failed", "quiet", "preempt",
   "alloced", "copy user", "flush seq", "io stat", "mixed merge", "pm",
-  "hashed", "mq_inflight", "no timeout", "nr bits"
+  "hashed", "mq_inflight", "no timeout", "op write zeroes", "nr bits"
 };
 
 static char const checkpoint_name[] = "checkpoint";


### PR DESCRIPTION
So far, output of tests on older kernel versions are not affected by these changes. Currently working to determine if test results on 4.15 kernel for btrfs-bugs branch tests are correct.