### PR TITLE
Makefile hack to pull in the proper header include.

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -1,3 +1,5 @@
+KERNEL_VERSION := $(shell uname -r)
+
 GCC = gcc
 GPP = g++
 DEBUG_FLAGS += -g -DDEBUG
@@ -9,7 +11,7 @@ TESTING := testing/log_on_off testing/test_get_log_ent_size
 
 MODULES = cow_brd disk_wrapper
 obj-m := $(addsuffix .o, $(MODULES))
-KDIR := /lib/modules/$(shell uname -r)/build
+KDIR := /lib/modules/$(KERNEL_VERSION)/build
 
 CM_TESTS_EXCLUDE = BaseTestCase.cpp
 CM_TESTS = \
@@ -21,6 +23,18 @@ CM_PERMUTERS = \
 		$(patsubst %.cpp, %.so, \
 			$(filter-out $(CM_PERMUTER_EXCLUDE), \
 				$(notdir $(wildcard $(CURDIR)/permuter/*.cpp))))
+
+# Some Makefile magic to get the right include for xattr depending on kernel
+# version. To avoid including kernel headers in user test cases, we don't want
+# to compare against the KERNEL_VERSION macro. Thanks to some random SO post for
+# how to compare the kernel version.
+KERNEL_MAJ := $(shell echo $(KERNEL_VERSION) | cut -f1 -d.)
+KERNEL_MIN := $(shell echo $(KERNEL_VERSION) | cut -f2 -d.)
+XATTR_DEF_FLAG :=
+ifeq ($(shell [ $(KERNEL_MAJ) -gt 4 -o \
+	\( $(KERNEL_MAJ) -eq 4 -a $(KERNEL_MIN) -ge 15 \) ] && echo true), true)
+XATTR_DEF_FLAG := -DNEW_XATTR_INC
+endif
 
 .PHONY: all modules c_harness user_tool $(CM_TESTS) $(CM_PERMUTERS) clean
 
@@ -100,7 +114,8 @@ $(BUILD_DIR)/tests/%.so: \
 		$(BUILD_DIR)/utils/communication/ClientCommandSender.o \
 		$(BUILD_DIR)/results/DataTestResult.o
 	mkdir -p $(@D)
-	$(GPP) $(GOPTS) $(GOTPSSO) -Wl,-soname,$(notdir $@) -o $@ $^
+	$(GPP) $(GOPTS) $(GOTPSSO) $(XATTR_DEF_FLAG) -Wl,-soname,$(notdir $@) \
+		-o $@ $^
 
 $(BUILD_DIR)/tests/%.o: \
 		tests/%.cpp

--- a/code/tests/generic_066.cpp
+++ b/code/tests/generic_066.cpp
@@ -22,8 +22,14 @@ https://www.spinics.net/lists/linux-btrfs/msg42162.html)
 #include <iostream>
 #include <dirent.h>
 #include <cstring>
-#include <attr/xattr.h>
 #include <errno.h>
+
+// Header file was changed in 4.15 kernel.
+#ifdef NEW_XATTR_INC
+#include <sys/xattr.h>
+#else
+#include <attr/xattr.h>
+#endif
 
 #include "BaseTestCase.h"
 #include "../user_tools/api/workload.h"


### PR DESCRIPTION
Currently for xattr header only as that changed in 4.15 kernels.