### PR TITLE
Minor Code Cleanups/Changes

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -50,7 +50,9 @@ all: \
 		permuters
 
 modules: \
-		$(foreach MOD, $(MODULES), $(addsuffix .ko, $(BUILD_DIR)/$(MOD)))
+		$(foreach MOD, $(MODULES), $(addsuffix .c, $(MOD))) \
+		$(BUILD_DIR)/Makefile
+	$(MAKE) -C $(KDIR) M=$(BUILD_DIR) src=$(CURDIR) modules
 
 c_harness: \
 		$(BUILD_DIR)/c_harness
@@ -77,11 +79,6 @@ permuters: \
 $(BUILD_DIR)/Makefile:
 	mkdir -p $(BUILD_DIR)
 	touch "$@"
-
-$(BUILD_DIR)/%.ko: \
-		%.c \
-		$(BUILD_DIR)/Makefile
-	$(MAKE) -C $(KDIR) M=$(BUILD_DIR) src=$(CURDIR) modules
 
 $(BUILD_DIR)/harness/%.o: \
 		harness/%.cpp

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -1089,8 +1089,6 @@ void Tester::log_disk_write_data(std::ostream &log) {
     "time" << " " << std::setw(18) << "sector" << " " << std::setw(18) <<
     "size" << std::endl;
   for (unsigned int i = 0; i < log_data.size(); ++i) {
-    std::cout << "logging data at address " << std::hex << &log_data.at(i) <<
-      std::dec << std::endl;
     log << std::setw(5) << i << ' ' << log_data.at(i);
   }
   log.precision(digits);

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -657,10 +657,10 @@ int Tester::test_check_random_permutations(const int num_rounds,
 
     // Accounting for time it took to run the test.
     if (check_res.first.count() > -1) {
-      timing_stats[FSCK_TIME] + check_res.first;
+      timing_stats[FSCK_TIME] += check_res.first;
     }
     if (check_res.second.count() > -1) {
-      timing_stats[TEST_CASE_TIME] + check_res.second;
+      timing_stats[TEST_CASE_TIME] += check_res.second;
     }
   }
 

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
   bool verbose = false;
   bool in_order_replay = true;
   bool permuted_order_replay = true;
-  int iterations = 1000;
+  int iterations = 10000;
   int disk_size = 10240;
   int option_idx = 0;
   ServerSocket* background_com = NULL;


### PR DESCRIPTION
Some changes to clean things up a bit in the Makefile as well as remove some accidental additions. Also increased the default number of tests to 10k (or until it can't find anymore unique crash states in a reasonable amount of time).

At this point, mount/unmount seem to be causing a fair amount of overhead, making run times longer. #81, which will change when fsck is run and how often the file system is mounted/unmounted during a test may help, but it looks like we will be bounded below by mount/unmount times and fsck.