### PR TITLE
Create subset permuter and ability to work with bio sectors

### DIFF
--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -161,8 +161,8 @@ class Tester {
       const std::vector<fs_testing::utils::disk_write>::iterator& start,
       const std::vector<fs_testing::utils::disk_write>::iterator& end);
   bool test_write_data(const int disk_fd,
-      const std::vector<fs_testing::permuter::EpochOpSector>::iterator& start,
-      const std::vector<fs_testing::permuter::EpochOpSector>::iterator& end);
+      const std::vector<fs_testing::utils::DiskWriteData>::iterator &start,
+      const std::vector<fs_testing::utils::DiskWriteData>::iterator &end);
 
   std::vector<std::chrono::milliseconds> test_fsck_and_user_test(
       const std::string device_path, const unsigned int last_checkpoint,

--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -154,9 +154,12 @@ class Tester {
   bool read_dirty_expire_time(int fd);
   bool write_dirty_expire_time(int fd, const char* time);
 
-  bool test_write_data(const int disk_fd,
+  bool test_write_data_dw(const int disk_fd,
       const std::vector<fs_testing::utils::disk_write>::iterator& start,
       const std::vector<fs_testing::utils::disk_write>::iterator& end);
+  bool test_write_data(const int disk_fd,
+      const std::vector<fs_testing::permuter::EpochOpSector>::iterator& start,
+      const std::vector<fs_testing::permuter::EpochOpSector>::iterator& end);
 
   std::vector<std::chrono::milliseconds> test_fsck_and_user_test(
       const std::string device_path, const unsigned int last_checkpoint,

--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -62,7 +62,8 @@ class Tester {
     NUM_TIME,
   };
 
-  Tester(const unsigned int device_size, const bool verbosity);
+  Tester(const unsigned int device_size, const unsigned int sector_size,
+      const bool verbosity);
   ~Tester();
   const bool verbose = false;
   void set_fs_type(const std::string type);
@@ -85,7 +86,8 @@ class Tester {
   int test_setup();
   int test_init_values(std::string mountDir, long filesysSize);
   int test_run();
-  int test_check_random_permutations(const int num_rounds, std::ofstream& log);
+  int test_check_random_permutations(const bool full_bio_replay,
+      const int num_rounds, std::ofstream& log);
   int test_check_log_replay(std::ofstream& log);
   int test_restore_log();
   int test_check_current();
@@ -147,6 +149,7 @@ class Tester {
   bool disk_mounted = false;
 
   int ioctl_fd = -1;
+  const unsigned int sector_size_;
   std::vector<fs_testing::utils::disk_write> log_data;
 
   int mount_device(const char* dev, const char* opts);

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -36,7 +36,7 @@
 #define DIRECTORY_PERMS \
   (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
 
-#define OPTS_STRING "bd:f:e:l:m:np:r:s:t:vIP"
+#define OPTS_STRING "bd:f:e:l:m:np:r:s:t:vFIPS:"
 
 namespace {
   unsigned int kSocketQueueDepth;
@@ -67,8 +67,10 @@ static const option long_options[] = {
   {"iterations", required_argument, NULL, 's'},
   {"fs-type", required_argument, NULL, 't'},
   {"verbose", no_argument, NULL, 'v'},
+  {"full-bio-replay", no_argument, NULL, 'F'},
   {"no-in-order-replay", no_argument, NULL, 'I'},
   {"no-permuted-order-replay", no_argument, NULL, 'P'},
+  {"sector-size", required_argument, NULL, 'S'},
   {0, 0, 0, 0},
 };
 
@@ -90,8 +92,10 @@ int main(int argc, char** argv) {
   bool verbose = false;
   bool in_order_replay = true;
   bool permuted_order_replay = true;
+  bool full_bio_replay = false;
   int iterations = 10000;
   int disk_size = 10240;
+  unsigned int sector_size = 512;
   int option_idx = 0;
   ServerSocket* background_com = NULL;
 
@@ -142,11 +146,17 @@ int main(int argc, char** argv) {
       case 'v':
         verbose = true;
         break;
+      case 'F':
+        full_bio_replay = true;
+        break;
       case 'I':
         in_order_replay = false;
         break;
       case 'P':
         permuted_order_replay = false;
+        break;
+      case 'S':
+        sector_size = atoi(optarg);
         break;
       case '?':
       default:
@@ -206,6 +216,11 @@ int main(int argc, char** argv) {
     return -1;
   }
 
+  if (sector_size <= 0) {
+    cerr << "Please give a positive number for the sector size" << endl;
+    return -1;
+  }
+
   // Create a socket to coordinate with the outside world.
   // TODO(ashmrtn): Fix permissions on the socket.
   /*
@@ -252,7 +267,7 @@ int main(int argc, char** argv) {
   }
 
 
-  Tester test_harness(disk_size, verbose);
+  Tester test_harness(disk_size, sector_size, verbose);
   test_harness.StartTestSuite();
 
   cout << "Inserting RAM disk module" << endl;
@@ -854,7 +869,8 @@ int main(int argc, char** argv) {
     logfile << "Writing profiled data to block device and checking with fsck" <<
       endl;
 
-    test_harness.test_check_random_permutations(iterations, logfile);
+    test_harness.test_check_random_permutations(full_bio_replay, iterations,
+        logfile);
 
     for (unsigned int i = 0; i < Tester::NUM_TIME; ++i) {
       cout << "\t" << (Tester::time_stats) i << ": " <<

--- a/code/permuter/Permuter.cpp
+++ b/code/permuter/Permuter.cpp
@@ -19,6 +19,7 @@ using std::size_t;
 using std::vector;
 
 using fs_testing::utils::disk_write;
+using fs_testing::utils::DiskWriteData;
 
 namespace {
 
@@ -74,6 +75,12 @@ vector<EpochOpSector> epoch_op::ToSectors(unsigned int sector_size) {
   return res;
 }
 
+DiskWriteData epoch_op::ToWriteData() {
+  return DiskWriteData(true, abs_index, 0,
+      op.metadata.write_sector * kKernelSectorSize, op.metadata.size,
+      op.get_data(), 0);
+}
+
 EpochOpSector::EpochOpSector() :
       parent(NULL), parent_sector_index(0), disk_offset(0), max_sector_size(0),
       size(0){ }
@@ -103,8 +110,18 @@ bool EpochOpSector::operator==(const EpochOpSector &other) const {
   return true;
 }
 
+bool EpochOpSector::operator!=(const EpochOpSector &other) const {
+  return !(*this == other);
+}
+
 void * EpochOpSector::GetData() {
   return parent->op.get_data().get() + (max_sector_size * parent_sector_index);
+}
+
+DiskWriteData EpochOpSector::ToWriteData() {
+  return DiskWriteData(false, parent->abs_index, parent_sector_index,
+      disk_offset, size, parent->op.get_data(),
+      (max_sector_size * parent_sector_index));
 }
 
 /*

--- a/code/permuter/Permuter.h
+++ b/code/permuter/Permuter.h
@@ -12,8 +12,6 @@
 namespace fs_testing {
 namespace permuter {
 
-using fs_testing::PermuteTestResult;
-
 // Declare just so that we can reference it in a function below.
 struct EpochOpSector;
 
@@ -72,10 +70,11 @@ class Permuter {
   virtual ~Permuter() {};
   void InitDataVector(unsigned int sector_size,
       std::vector<fs_testing::utils::disk_write> &data);
-  bool GenerateCrashState(std::vector<EpochOpSector>& res,
-      PermuteTestResult &log_data);
-  bool GenerateSectorCrashState(std::vector<EpochOpSector>& res,
-      PermuteTestResult &log_data);
+  bool GenerateCrashState(std::vector<fs_testing::utils::DiskWriteData> &res,
+      fs_testing::PermuteTestResult &log_data);
+  bool GenerateSectorCrashState(
+      std::vector<fs_testing::utils::DiskWriteData> &res,
+      fs_testing::PermuteTestResult &log_data);
 
  protected:
   std::vector<epoch>* GetEpochs();
@@ -93,9 +92,10 @@ class Permuter {
  private:
   virtual void init_data(std::vector<epoch> *data) = 0;
   virtual bool gen_one_state(std::vector<epoch_op>& res,
-      PermuteTestResult &log_data) = 0;
-  virtual bool gen_one_sector_state(std::vector<EpochOpSector> &res,
-      PermuteTestResult &log_data) = 0;
+      fs_testing::PermuteTestResult &log_data) = 0;
+  virtual bool gen_one_sector_state(
+      std::vector<fs_testing::utils::DiskWriteData> &res,
+      fs_testing::PermuteTestResult &log_data) = 0;
 
   bool FindOverlapsAndInsert(fs_testing::utils::disk_write &dw,
       std::list<std::pair<unsigned int, unsigned int>> &ranges) const;

--- a/code/permuter/Permuter.h
+++ b/code/permuter/Permuter.h
@@ -28,6 +28,8 @@ struct BioVectorEqual {
 
 struct epoch_op {
   std::vector<EpochOpSector> ToSectors(unsigned int sector_size);
+  fs_testing::utils::DiskWriteData ToWriteData();
+
   unsigned int abs_index;
   fs_testing::utils::disk_write op;
 };
@@ -51,7 +53,10 @@ struct EpochOpSector {
       unsigned int disk_offset, unsigned int size,
       unsigned int max_sector_size);
   bool operator==(const EpochOpSector &other) const;
+  bool operator!=(const EpochOpSector &other) const;
   void * GetData();
+  fs_testing::utils::DiskWriteData ToWriteData();
+
   epoch_op *parent;
   unsigned int parent_sector_index;
   unsigned int disk_offset;

--- a/code/permuter/Permuter.h
+++ b/code/permuter/Permuter.h
@@ -65,17 +65,33 @@ struct EpochOpSector {
 class Permuter {
  public:
   virtual ~Permuter() {};
-  void InitDataVector(std::vector<fs_testing::utils::disk_write> &data);
+  void InitDataVector(unsigned int sector_size,
+      std::vector<fs_testing::utils::disk_write> &data);
   bool GenerateCrashState(std::vector<EpochOpSector>& res,
+      PermuteTestResult &log_data);
+  bool GenerateSectorCrashState(std::vector<EpochOpSector>& res,
       PermuteTestResult &log_data);
 
  protected:
   std::vector<epoch>* GetEpochs();
+  /*
+   * Given a vector of sectors ordered in time (i.e. the submission time of a
+   * sector at a higher index in the vector is later than the submission time of
+   * a sector at a lower index in the vector), remove earlier sectors that write
+   * to the same disk address as later sectors.
+   */
+  std::vector<EpochOpSector> CoalesceSectors(
+      std::vector<EpochOpSector> &sector_list);
+
+  unsigned int sector_size_;
 
  private:
   virtual void init_data(std::vector<epoch> *data) = 0;
   virtual bool gen_one_state(std::vector<epoch_op>& res,
       PermuteTestResult &log_data) = 0;
+  virtual bool gen_one_sector_state(std::vector<EpochOpSector> &res,
+      PermuteTestResult &log_data) = 0;
+
   bool FindOverlapsAndInsert(fs_testing::utils::disk_write &dw,
       std::list<std::pair<unsigned int, unsigned int>> &ranges) const;
 

--- a/code/permuter/RandomPermuter.cpp
+++ b/code/permuter/RandomPermuter.cpp
@@ -171,53 +171,6 @@ void RandomPermuter::subset_epoch(
   *res_start = epoch.ops.back();
 }
 
-
-void RandomPermuter::permute_epoch(
-      vector<epoch_op>::iterator& res_start,
-      vector<epoch_op>::iterator& res_end,
-      epoch& epoch) {
-  assert(distance(res_start, res_end) <= epoch.ops.size());
-
-  // Even if the number of bios we're placing is less than the number in the
-  // epoch, allow any bio but the barrier (if present) to be picked.
-  unsigned int slots = epoch.ops.size();
-  if (epoch.has_barrier) {
-    --slots;
-  }
-
-  // Fill the list with the empty slots, either [0, epoch.size() - 1] or
-  // [0, epoch.size() - 2]. Prefer a list so that removals are fast. We have
-  // this so that each time we pick a number we can find a bio which we haven't
-  // already placed.
-  list<unsigned int> empty_slots(slots);
-  iota(empty_slots.begin(), empty_slots.end(), 0);
-
-  // First case is when we are placing a subset of the bios, the second is when
-  // we are placing all the bios but a barrier operation is present.
-  while (res_start != res_end && !empty_slots.empty()) {
-    // Uniform distribution includes both ends, so we need to subtract 1 from
-    // the size.
-    uniform_int_distribution<unsigned int> uid(0, empty_slots.size() - 1);
-    auto shift = empty_slots.begin();
-    advance(shift, uid(rand));
-    *res_start = epoch.ops.at(*shift);
-    ++res_start;
-    empty_slots.erase(shift);
-  }
-
-  // We are only placing part of an epoch so we need to return here.
-  if (res_start == res_end) {
-    return;
-  }
-
-  assert(epoch.has_barrier);
-
-  // Place the barrier operation if it exists since the entire vector already
-  // exists (i.e. we won't cause extra shifting when adding the other elements).
-  // Decrement out count of empty slots since we have filled one.
-  *res_start = epoch.ops.back();
-}
-
 }  // namespace permuter
 }  // namespace fs_testing
 

--- a/code/permuter/RandomPermuter.cpp
+++ b/code/permuter/RandomPermuter.cpp
@@ -1,9 +1,10 @@
+#include <cassert>
+
+#include <algorithm>
 #include <iterator>
 #include <list>
 #include <numeric>
 #include <vector>
-#include <algorithm>
-#include <cassert>
 
 #include "Permuter.h"
 #include "RandomPermuter.h"
@@ -59,7 +60,7 @@ bool RandomPermuter::gen_one_state(vector<epoch_op>& res,
   }
   total_elements += num_requests;
   res.resize(total_elements);
-  log_data.crash_state.resize(total_elements);
+
   // Tell CrashMonkey the most recently seen checkpoint for the crash state
   // we're generating. We can't just pull the last epoch because it could be the
   // case that there's a checkpoint at the end of this disk write epoch.
@@ -107,10 +108,6 @@ bool RandomPermuter::gen_one_state(vector<epoch_op>& res,
     }
   }
 
-  // Messy bit to add everything to the logging data struct.
-  for (unsigned int i = 0; i < res.size(); ++i) {
-    log_data.crash_state.at(i) = res.at(i).abs_index;
-  }
   return true;
 }
 

--- a/code/permuter/RandomPermuter.h
+++ b/code/permuter/RandomPermuter.h
@@ -31,9 +31,6 @@ class RandomPermuter : public Permuter {
   virtual void init_data(std::vector<epoch> *data);
   virtual bool gen_one_state(std::vector<epoch_op>& res,
       PermuteTestResult &log_data);
-  void permute_epoch(
-      std::vector<epoch_op>::iterator& res_start,
-      std::vector<epoch_op>::iterator& res_end, epoch& epoch);
   void subset_epoch(
       std::vector<epoch_op>::iterator &res_start,
       std::vector<epoch_op>::iterator &res_end, epoch &epoch);

--- a/code/permuter/RandomPermuter.h
+++ b/code/permuter/RandomPermuter.h
@@ -13,6 +13,15 @@ namespace permuter {
 
 using fs_testing::PermuteTestResult;
 
+class GenRandom {
+ public:
+  GenRandom();
+  int operator()(int max);
+
+ private:
+  std::mt19937 rand;
+};
+
 class RandomPermuter : public Permuter {
  public:
   RandomPermuter();
@@ -26,10 +35,11 @@ class RandomPermuter : public Permuter {
       std::vector<epoch_op>::iterator& res_start,
       std::vector<epoch_op>::iterator& res_end, epoch& epoch);
   void subset_epoch(
-      std::vector<epoch_op>::iterator& res_start,
-      std::vector<epoch_op>::iterator& res_end, epoch& epoch);
+      std::vector<epoch_op>::iterator &res_start,
+      std::vector<epoch_op>::iterator &res_end, epoch &epoch);
 
   std::mt19937 rand;
+  GenRandom subset_random_;
 };
 
 }  // namespace permuter

--- a/code/permuter/RandomPermuter.h
+++ b/code/permuter/RandomPermuter.h
@@ -31,6 +31,9 @@ class RandomPermuter : public Permuter {
   virtual void init_data(std::vector<epoch> *data);
   virtual bool gen_one_state(std::vector<epoch_op>& res,
       PermuteTestResult &log_data);
+  virtual bool gen_one_sector_state(std::vector<EpochOpSector> &res,
+      PermuteTestResult &log_data) override;
+
   void subset_epoch(
       std::vector<epoch_op>::iterator &res_start,
       std::vector<epoch_op>::iterator &res_end, epoch &epoch);

--- a/code/permuter/RandomPermuter.h
+++ b/code/permuter/RandomPermuter.h
@@ -25,6 +25,9 @@ class RandomPermuter : public Permuter {
   void permute_epoch(
       std::vector<epoch_op>::iterator& res_start,
       std::vector<epoch_op>::iterator& res_end, epoch& epoch);
+  void subset_epoch(
+      std::vector<epoch_op>::iterator& res_start,
+      std::vector<epoch_op>::iterator& res_end, epoch& epoch);
 
   std::mt19937 rand;
 };

--- a/code/permuter/RandomPermuter.h
+++ b/code/permuter/RandomPermuter.h
@@ -31,12 +31,21 @@ class RandomPermuter : public Permuter {
   virtual void init_data(std::vector<epoch> *data);
   virtual bool gen_one_state(std::vector<epoch_op>& res,
       PermuteTestResult &log_data);
-  virtual bool gen_one_sector_state(std::vector<EpochOpSector> &res,
+  virtual bool gen_one_sector_state(
+      std::vector<fs_testing::utils::DiskWriteData> &res,
       PermuteTestResult &log_data) override;
 
   void subset_epoch(
       std::vector<epoch_op>::iterator &res_start,
       std::vector<epoch_op>::iterator &res_end, epoch &epoch);
+  /*
+   * Add the operations in the epoch_ops contained in the epochs [start, end).
+   */
+  void AddEpochs(
+      const std::vector<fs_testing::utils::DiskWriteData>::iterator &res_start,
+      const std::vector<fs_testing::utils::DiskWriteData>::iterator &res_end,
+      const std::vector<epoch>::iterator &start,
+      const std::vector<epoch>::iterator &end);
 
   std::mt19937 rand;
   GenRandom subset_random_;

--- a/code/results/PermuteTestResult.cpp
+++ b/code/results/PermuteTestResult.cpp
@@ -6,43 +6,32 @@ using std::ostream;
 using std::to_string;
 
 ostream& PermuteTestResult::PrintCrashStateSize(ostream& os) const {
-  if (crash_state.empty() && sector_crash_state.empty()) {
-    os << "0 bios";
-  } else if (!crash_state.empty()) {
-    os << to_string(crash_state.size()) << " bios";
+  if (crash_state.empty()) {
+    os << "0 bios/sectors";
   } else {
-    os << to_string(sector_crash_state.size()) << " sectors";
+    os << to_string(crash_state.size()) << " bios/sectors";
   }
   return os;
 }
 
 ostream& PermuteTestResult::PrintCrashState(ostream& os) const {
-  if (crash_state.empty() && sector_crash_state.empty()) {
+  if (crash_state.empty()) {
     return os;
   }
-  if (!crash_state.empty()) {
-    return PrintFullBioCrashState(os);
-  } else {
-    return PrintSectorCrashState(os);
-  }
-}
 
-ostream& PermuteTestResult::PrintFullBioCrashState(ostream &os) const {
   for (unsigned int i = 0; i < crash_state.size() - 1; ++i) {
-    os << to_string(crash_state.at(i)) << ", ";
+    os << "(" << to_string(crash_state.at(i).bio_index);
+    if (!crash_state.at(i).full_bio) {
+      os << ", " << to_string(crash_state.at(i).bio_sector_index);
+    }
+    os << "), ";
   }
-  os << to_string(crash_state.back());
-  return os;
-}
 
-ostream& PermuteTestResult::PrintSectorCrashState(ostream &os) const {
-  for (unsigned int i = 0; i < sector_crash_state.size() - 1; ++i) {
-    std::pair<unsigned int, unsigned int> sector = sector_crash_state.at(i);
-    os << "(" << to_string(sector.first) << ", " << to_string(sector.second) <<
-      "), ";
+  os << "(" << to_string(crash_state.back().bio_index);
+  if (!crash_state.back().full_bio) {
+    os << ", " << to_string(crash_state.back().bio_sector_index);
   }
-  std::pair<unsigned int, unsigned int> sector = sector_crash_state.back();
-  os << "(" << to_string(sector.first) << ", " << sector.second << ")";
+  os << ")";
 
   return os;
 }

--- a/code/results/PermuteTestResult.cpp
+++ b/code/results/PermuteTestResult.cpp
@@ -3,17 +3,47 @@
 namespace fs_testing {
 
 using std::ostream;
-using std::string;
 using std::to_string;
 
+ostream& PermuteTestResult::PrintCrashStateSize(ostream& os) const {
+  if (crash_state.empty() && sector_crash_state.empty()) {
+    os << "0 bios";
+  } else if (!crash_state.empty()) {
+    os << to_string(crash_state.size()) << " bios";
+  } else {
+    os << to_string(sector_crash_state.size()) << " sectors";
+  }
+  return os;
+}
+
 ostream& PermuteTestResult::PrintCrashState(ostream& os) const {
-  if (crash_state.size() == 0) {
+  if (crash_state.empty() && sector_crash_state.empty()) {
     return os;
   }
+  if (!crash_state.empty()) {
+    return PrintFullBioCrashState(os);
+  } else {
+    return PrintSectorCrashState(os);
+  }
+}
+
+ostream& PermuteTestResult::PrintFullBioCrashState(ostream &os) const {
   for (unsigned int i = 0; i < crash_state.size() - 1; ++i) {
     os << to_string(crash_state.at(i)) << ", ";
   }
   os << to_string(crash_state.back());
+  return os;
+}
+
+ostream& PermuteTestResult::PrintSectorCrashState(ostream &os) const {
+  for (unsigned int i = 0; i < sector_crash_state.size() - 1; ++i) {
+    std::pair<unsigned int, unsigned int> sector = sector_crash_state.at(i);
+    os << "(" << to_string(sector.first) << ", " << to_string(sector.second) <<
+      "), ";
+  }
+  std::pair<unsigned int, unsigned int> sector = sector_crash_state.back();
+  os << "(" << to_string(sector.first) << ", " << sector.second << ")";
+
   return os;
 }
 

--- a/code/results/PermuteTestResult.h
+++ b/code/results/PermuteTestResult.h
@@ -3,16 +3,23 @@
 
 #include <iostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace fs_testing {
 
 class PermuteTestResult {
  public:
+  std::ostream& PrintCrashStateSize(std::ostream& os) const;
   std::ostream& PrintCrashState(std::ostream& os) const;
 
   unsigned int last_checkpoint;
   std::vector<unsigned int> crash_state;
+  std::vector<std::pair<unsigned int, unsigned int>> sector_crash_state;
+
+ private:
+  std::ostream& PrintFullBioCrashState(std::ostream &os) const;
+  std::ostream& PrintSectorCrashState(std::ostream &os) const;
 };
 
 }  // namespace fs_testing

--- a/code/results/PermuteTestResult.h
+++ b/code/results/PermuteTestResult.h
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include "../utils/utils.h"
+
 namespace fs_testing {
 
 class PermuteTestResult {
@@ -14,12 +16,8 @@ class PermuteTestResult {
   std::ostream& PrintCrashState(std::ostream& os) const;
 
   unsigned int last_checkpoint;
-  std::vector<unsigned int> crash_state;
-  std::vector<std::pair<unsigned int, unsigned int>> sector_crash_state;
+  std::vector<fs_testing::utils::DiskWriteData> crash_state;
 
- private:
-  std::ostream& PrintFullBioCrashState(std::ostream &os) const;
-  std::ostream& PrintSectorCrashState(std::ostream &os) const;
 };
 
 }  // namespace fs_testing

--- a/code/results/SingleTestInfo.cpp
+++ b/code/results/SingleTestInfo.cpp
@@ -40,7 +40,9 @@ void SingleTestInfo::PrintResults(ostream& os) const {
   } else {
     os << data_test.error_description << endl;
   }
-  os << "\tcrash state (" << permute_data.crash_state.size() << " bios): ";
+  os << "\tcrash state (";
+  permute_data.PrintCrashStateSize(os);
+  os << "): ";
   permute_data.PrintCrashState(os) << endl;
   os << "\tlast checkpoint: " << permute_data.last_checkpoint << endl;
   os << "\tfsck result: ";

--- a/code/utils/utils.cpp
+++ b/code/utils/utils.cpp
@@ -293,5 +293,26 @@ void disk_write::clear_data() {
   data.reset();
 }
 
+
+DiskWriteData::DiskWriteData() :
+      full_bio(false), bio_index(0), bio_sector_index(0), disk_offset(0),
+      size(0), data_offset_(0) {
+  data_base_.reset();
+}
+
+DiskWriteData::DiskWriteData(bool full_bio, unsigned int bio_index,
+    unsigned int bio_sector_index ,unsigned int disk_offset,
+    unsigned int size, std::shared_ptr<char> data_base,
+    unsigned int data_offset) :
+      full_bio(full_bio), bio_index(bio_index),
+      bio_sector_index(bio_sector_index), disk_offset(disk_offset),
+      size(size), data_offset_(data_offset) {
+  data_base_ = data_base;
+}
+
+void * DiskWriteData::GetData() {
+  return (void*) (data_base_.get() + data_offset_);
+}
+
 }  // namespace utils
 }  // namespace fs_testing


### PR DESCRIPTION
The subset permuter works with subsets of bios or sectors (irrespective of order) instead of unique permutations of bios or sectors. This should help reduce the number of crash states that need exploring because states that have the same bios or sectors in the epoch that was crashed in should be equivalent (as long as they don't overlap).

Additionally, implement a new mode that allows CrashMonkey to work with sectors of the bios instead of complete bios. When working with sectors, the `-S <size>` flag can be used to control the size of the sectors the bios are split into. To go back to working with full bios only, give the `-F` flag.