### PR TITLE
cow_brd read unmodified data from parent in snapshot disk fix

### DIFF
--- a/code/cow_brd.c
+++ b/code/cow_brd.c
@@ -333,7 +333,7 @@ static void copy_from_brd(void *dst, struct brd_device *brd, sector_t sector,
         (page = brd_lookup_page(brd->parent_brd, sector))) {
       // Present in the old radix tree so this page has not been modified.
       src = kmap_atomic(page);
-      memcpy(dst, src + offset, copy);
+      memcpy(dst, src, copy);
       kunmap_atomic(src);
     } else {
       // Page doesn't exist in either radix tree so it must never have been


### PR DESCRIPTION
Stems from a copy/paste error. If a range of data spanning multiple pages was
requested from a disk snapshot and the snapshot had not modified any of that
data (i.e., it was reading the data from the parent device) then an incorrect
offset into the second page of data was used when copying data from the second
page.