### PR TITLE
Add file system specific delay times.

### DIFF
--- a/code/harness/FsSpecific.cpp
+++ b/code/harness/FsSpecific.cpp
@@ -44,15 +44,19 @@ FsSpecific* GetFsSpecific(std::string &fs_type) {
 
 /******************************* Ext File Systems *****************************/
 constexpr char Ext2FsSpecific::kFsType[];
-Ext2FsSpecific::Ext2FsSpecific() : ExtFsSpecific(Ext2FsSpecific::kFsType) { }
+Ext2FsSpecific::Ext2FsSpecific() :
+  ExtFsSpecific(Ext2FsSpecific::kFsType, Ext2FsSpecific::kDelaySeconds) { }
 
 constexpr char Ext3FsSpecific::kFsType[];
-Ext3FsSpecific::Ext3FsSpecific() : ExtFsSpecific(Ext3FsSpecific::kFsType) { }
+Ext3FsSpecific::Ext3FsSpecific() :
+  ExtFsSpecific(Ext3FsSpecific::kFsType, Ext3FsSpecific::kDelaySeconds) { }
 
 constexpr char Ext4FsSpecific::kFsType[];
-Ext4FsSpecific::Ext4FsSpecific() : ExtFsSpecific(Ext4FsSpecific::kFsType) { }
+Ext4FsSpecific::Ext4FsSpecific() :
+  ExtFsSpecific(Ext4FsSpecific::kFsType, Ext4FsSpecific::kDelaySeconds) { }
 
-ExtFsSpecific::ExtFsSpecific(std::string type) : fs_type_(type) { }
+ExtFsSpecific::ExtFsSpecific(std::string type, unsigned int delay_seconds) :
+  fs_type_(type), delay_seconds_(delay_seconds) { }
 
 string ExtFsSpecific::GetMkfsCommand(string &device_path) {
   return string(kMkfsStart) + fs_type_ + " " +
@@ -96,6 +100,10 @@ string ExtFsSpecific::GetFsTypeString() {
   return string(Ext4FsSpecific::kFsType);
 }
 
+unsigned int ExtFsSpecific::GetPostRunDelaySeconds() {
+  return delay_seconds_;
+}
+
 /******************************* Btrfs ****************************************/
 constexpr char BtrfsFsSpecific::kFsType[];
 
@@ -128,6 +136,10 @@ FileSystemTestResult::ErrorType BtrfsFsSpecific::GetFsckReturn(
 
 string BtrfsFsSpecific::GetFsTypeString() {
   return string(BtrfsFsSpecific::kFsType);
+}
+
+unsigned int BtrfsFsSpecific::GetPostRunDelaySeconds() {
+  return BtrfsFsSpecific::kDelaySeconds;
 }
 
 /******************************* F2fs *****************************************/
@@ -165,6 +177,10 @@ string F2fsFsSpecific::GetFsTypeString() {
   return string(F2fsFsSpecific::kFsType);
 }
 
+unsigned int F2fsFsSpecific::GetPostRunDelaySeconds() {
+  return F2fsFsSpecific::kDelaySeconds;
+}
+
 /******************************* Xfs ******************************************/
 constexpr char XfsFsSpecific::kFsType[];
 
@@ -192,6 +208,10 @@ FileSystemTestResult::ErrorType XfsFsSpecific::GetFsckReturn(
 
 string XfsFsSpecific::GetFsTypeString() {
   return string(XfsFsSpecific::kFsType);
+}
+
+unsigned int XfsFsSpecific::GetPostRunDelaySeconds() {
+  return XfsFsSpecific::kDelaySeconds;
 }
 
 }  // namespace fs_testing

--- a/code/harness/FsSpecific.h
+++ b/code/harness/FsSpecific.h
@@ -46,6 +46,12 @@ class FsSpecific {
    */
   virtual fs_testing::FileSystemTestResult::ErrorType
     GetFsckReturn(int return_code) = 0;
+
+  /*
+   * Return the number of seconds to wait after a test case's run() method so
+   * that all relevant disk I/O will be properly recorded.
+   */
+  virtual unsigned int GetPostRunDelaySeconds() = 0;
 };
 
 class ExtFsSpecific : public FsSpecific {
@@ -56,30 +62,35 @@ class ExtFsSpecific : public FsSpecific {
   virtual std::string GetFsckCommand(const std::string &fs_path);
   virtual fs_testing::FileSystemTestResult::ErrorType GetFsckReturn(
       int return_code);
+  virtual unsigned int GetPostRunDelaySeconds() override;
 
  protected:
-  ExtFsSpecific(std::string type);
+  ExtFsSpecific(std::string type, unsigned int delay_seconds);
 
  private:
   const std::string fs_type_;
+  const unsigned int delay_seconds_;
 };
 
 class Ext2FsSpecific : public ExtFsSpecific {
  public:
   Ext2FsSpecific();
   static constexpr char kFsType[] = "ext2";
+  static const unsigned int kDelaySeconds = 120;
 };
 
 class Ext3FsSpecific : public ExtFsSpecific {
  public:
   Ext3FsSpecific();
   static constexpr char kFsType[] = "ext3";
+  static const unsigned int kDelaySeconds = 120;
 };
 
 class Ext4FsSpecific : public ExtFsSpecific {
  public:
   Ext4FsSpecific();
   static constexpr char kFsType[] = "ext4";
+  static const unsigned int kDelaySeconds = 36;
 };
 
 class BtrfsFsSpecific : public FsSpecific {
@@ -90,8 +101,10 @@ class BtrfsFsSpecific : public FsSpecific {
   virtual std::string GetFsckCommand(const std::string &fs_path);
   virtual fs_testing::FileSystemTestResult::ErrorType GetFsckReturn(
       int return_code);
+  virtual unsigned int GetPostRunDelaySeconds() override;
 
   static constexpr char kFsType[] = "btrfs";
+  static const unsigned int kDelaySeconds = 34;
 };
 
 class F2fsFsSpecific : public FsSpecific {
@@ -102,8 +115,10 @@ class F2fsFsSpecific : public FsSpecific {
   virtual std::string GetFsckCommand(const std::string &fs_path);
   virtual fs_testing::FileSystemTestResult::ErrorType GetFsckReturn(
       int return_code);
+  virtual unsigned int GetPostRunDelaySeconds() override;
 
   static constexpr char kFsType[] = "f2fs";
+  static const unsigned int kDelaySeconds = 71;
 };
 
 class XfsFsSpecific : public FsSpecific {
@@ -114,8 +129,10 @@ class XfsFsSpecific : public FsSpecific {
   virtual std::string GetFsckCommand(const std::string &fs_path);
   virtual fs_testing::FileSystemTestResult::ErrorType GetFsckReturn(
       int return_code);
+  virtual unsigned int GetPostRunDelaySeconds() override;
 
   static constexpr char kFsType[] = "xfs";
+  static const unsigned int kDelaySeconds = 120;
 };
 
 /*

--- a/code/harness/FsSpecific.h
+++ b/code/harness/FsSpecific.h
@@ -76,14 +76,14 @@ class Ext2FsSpecific : public ExtFsSpecific {
  public:
   Ext2FsSpecific();
   static constexpr char kFsType[] = "ext2";
-  static const unsigned int kDelaySeconds = 120;
+  static const unsigned int kDelaySeconds = 15;
 };
 
 class Ext3FsSpecific : public ExtFsSpecific {
  public:
   Ext3FsSpecific();
   static constexpr char kFsType[] = "ext3";
-  static const unsigned int kDelaySeconds = 120;
+  static const unsigned int kDelaySeconds = 36;
 };
 
 class Ext4FsSpecific : public ExtFsSpecific {

--- a/code/harness/Tester.cpp
+++ b/code/harness/Tester.cpp
@@ -131,6 +131,10 @@ void Tester::EndTestSuite() {
   current_test_suite_ = NULL;
 }
 
+unsigned int Tester::GetPostRunDelay() {
+  return fs_specific_ops_->GetPostRunDelaySeconds();
+}
+
 int Tester::clone_device() {
   std::cout << "cloning device " << device_raw << std::endl;
   if (ioctl(cow_brd_fd, COW_BRD_SNAPSHOT) < 0) {

--- a/code/harness/Tester.h
+++ b/code/harness/Tester.h
@@ -126,6 +126,8 @@ class Tester {
   void StartTestSuite();
   void EndTestSuite();
 
+  unsigned int GetPostRunDelay();
+
   // TODO(ashmrtn): Figure out why making these private slows things down a lot.
  private:
   FsSpecific *fs_specific_ops_ = NULL;

--- a/code/harness/c_harness.cpp
+++ b/code/harness/c_harness.cpp
@@ -30,7 +30,6 @@
 #define TEST_DIRTY_EXPIRE_TIME_CENTISECS 3000
 #define TEST_DIRTY_EXPIRE_TIME_STRING \
   TO_STRING(TEST_DIRTY_EXPIRE_TIME_CENTISECS)
-#define WRITE_DELAY ((TEST_DIRTY_EXPIRE_TIME_CENTISECS / 100) * 4)
 #define MOUNT_DELAY 1
 
 #define DIRECTORY_PERMS \
@@ -78,7 +77,6 @@ int main(int argc, char** argv) {
   cout << "running " << argv << endl;
 
   string dirty_expire_time_centisecs(TEST_DIRTY_EXPIRE_TIME_STRING);
-  unsigned long int test_sleep_delay = WRITE_DELAY;
   string fs_type("ext4");
   string flags_dev("/dev/vda");
   string test_dev("/dev/ram0");
@@ -729,7 +727,10 @@ int main(int argc, char** argv) {
     // layer and then stop logging writes.
     cout << "Waiting for writeback delay" << endl;
     logfile << "Waiting for writeback delay" << endl;
-    sleep(WRITE_DELAY);
+    unsigned int sleep_time = test_harness.GetPostRunDelay();
+    while (sleep_time > 0) {
+      sleep_time = sleep(sleep_time);
+    }
 
     cout << "Disabling wrapper device logging" << endl;
     logfile << "Disabling wrapper device logging" << endl;


### PR DESCRIPTION
ext2/3 file systems have not yet been profiled, so they are defaulted at 120
second delays.