### PR TITLE
Fixing reported issues in Ace

### DIFF
--- a/ace/ace.py
+++ b/ace/ace.py
@@ -58,7 +58,6 @@ TruncateOptions = ['unaligned']
 # We currently support : creat, mkdir, falloc, write, dwrite, link, unlink, remove, rename, fsetxattr, removexattr, truncate, mmapwrite, symlink, fsync, fdatasync, sync
 OperationSet = ['creat', 'mkdir', 'falloc', 'write', 'dwrite','mmapwrite', 'link', 'unlink', 'remove', 'rename', 'fsetxattr', 'removexattr', 'truncate', 'fdatasync']
 
-
 #The sequences we want to reach to, to reproduce known bugs.
 expected_sequence = []
 expected_sync_sequence = []
@@ -86,6 +85,8 @@ def SiblingOf(file):
         return 'B'
     elif file == 'B':
         return 'A'
+    elif file == 'AC' :
+	return 'AC'
     elif file == 'test':
         return 'test'
 

--- a/copy_diff.sh
+++ b/copy_diff.sh
@@ -24,7 +24,7 @@ then
 	fi
 	rm build/diff*
 else
-	if [ -e build/diff* ]
+	if [ -n "$(ls build | grep diff)" ]
 	then
    		rm build/diff*
 		echo -e "${green}${bold} : Passed test${reset}"


### PR DESCRIPTION
1.  Nested mode bug arises when the range of files that you could fsync/fdatasync includes a 'None' option. This could happen if we don't return the right parent/sibling of all involved files. 

When we added a new nested directory A/C we missed out updating what it's sibling is, which therefore returned 'None'. This was included in the list of files that could be persisted, throwing a None type error. So the fix was to return the right sibling. 

Whenever a new level of nesting, file or directory is added to Ace, ensure that you update their parent and sibling in the definitions Parent() and SiblingOf().

2. The other change was in copy_diff.sh, where we could erroneously display that the test could not be run, although it completed successfully. This would occur if there were multiple empty diff files as reported by #126. Fix this by changing how we check for the existence of empty diff files.