### PR TITLE
Port CrashMonkey to 4.9 series kernels

### DIFF
--- a/code/bio_alias.h
+++ b/code/bio_alias.h
@@ -46,6 +46,18 @@
 #define BIO_DISCARD_FLAG        REQ_DISCARD
 #define BIO_IS_WRITE(bio)       (!!(bio_rw(bio) & REQ_WRITE))
 
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0) \
+  && LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
+
+#define BI_RW                   bi_opf
+#define BI_DISK                 bi_bdev->bd_disk
+#define BI_SIZE                 bi_iter.bi_size
+#define BI_SECTOR               bi_iter.bi_sector
+#define BIO_ENDIO(bio, err)     bio_endio(bio)
+#define BIO_IO_ERR(bio, err)    bio_io_error(bio)
+#define BIO_DISCARD_FLAG        REQ_OP_DISCARD
+#define BIO_IS_WRITE(bio)       op_is_write(bio_op(bio))
+
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) \
   && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
 

--- a/code/cow_brd.c
+++ b/code/cow_brd.c
@@ -394,7 +394,7 @@ static blk_qc_t brd_make_request(struct request_queue *q, struct bio *bio) {
     goto out_err;
   }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
   if (unlikely(bio->BI_RW & BIO_DISCARD_FLAG)) {
 #else
   if (unlikely(bio_op(bio) == BIO_DISCARD_FLAG)) {

--- a/code/disk_wrapper.c
+++ b/code/disk_wrapper.c
@@ -49,16 +49,16 @@ static struct hwm_device {
   struct gendisk* gd;
   bool log_on;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 12, 0) && \
-  LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
- (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
-  LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
- (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
-  LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   struct block_device* target_dev;
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
   struct gendisk* target_dev;
   u8 target_partno;
   struct block_device* target_bd;
@@ -334,8 +334,8 @@ static unsigned long long convert_flags(unsigned long long flags) {
 #endif
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
-     LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
 // These are flags present in 4.4 but not 3.13.
   if (flags & REQ_PM) {
     res |= HWM_PM_FLAG;
@@ -421,8 +421,8 @@ static bool should_log(struct bio *bio) {
     (bio->BI_RW & REQ_FLUSH || bio->BI_RW & REQ_FUA ||
      bio->BI_RW & REQ_FLUSH_SEQ || bio->BI_RW & REQ_WRITE ||
      bio->BI_RW & REQ_DISCARD);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) \
-    && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) \
+    && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0))
   // Other REQ_OP_xx functions are odd numbers, meaning they set the
   // REQ_OP_WRITE bit which we already check for (ex. REQ_OP_WRITE_SAME = 7).
   return
@@ -462,15 +462,15 @@ static void print_rw_flags(unsigned long rw, unsigned long flags) {
 // TODO(ashmrtn): Currently not thread safe/reentrant. Make it so.
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 12, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
-     LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
 static void disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
-    LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0))
 static blk_qc_t disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
 #else
 #error "Unsupported kernel version: CrashMonkey has not been tested with " \
@@ -574,12 +574,12 @@ static blk_qc_t disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
   hwm = (struct hwm_device*) q->queuedata;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 12, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
-   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
-   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   bio->bi_bdev = hwm->target_dev;
   submit_bio(bio->BI_RW, bio);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
@@ -656,12 +656,12 @@ static int __init disk_wrapper_init(void) {
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 12, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
-   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   Device.target_dev = target_device;
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
@@ -685,12 +685,12 @@ static int __init disk_wrapper_init(void) {
   }
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 12, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
-   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   // Field not present in kernel 4.15+.
   flush_flags = flags_device->bd_queue->flush_flags;
 #endif
@@ -723,12 +723,12 @@ static int __init disk_wrapper_init(void) {
   // Make this queue have the same flags as the queue we're feeding into.
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 12, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
-   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)) 
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   Device.gd->queue->flush_flags = flush_flags;
 #endif
   Device.gd->queue->queue_flags = queue_flags;
@@ -742,7 +742,7 @@ static int __init disk_wrapper_init(void) {
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   printk(KERN_INFO "hwm: working with queue with:\n\tflush flags 0x%lx\n",
       Device.gd->queue->flush_flags);
 #endif
@@ -760,16 +760,16 @@ static int __init disk_wrapper_init(void) {
 static void __exit hello_cleanup(void) {
   free_logs();
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 12, 0) && \
-  LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
-   (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
-  LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)) || \
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
-   LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
   blkdev_put(Device.target_dev, FMODE_READ);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
-  LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
   blkdev_put(Device.target_bd, FMODE_READ);
 #else
 #error "Unsupported kernel version: CrashMonkey has not been tested with " \

--- a/docs/CrashMonkey.md
+++ b/docs/CrashMonkey.md
@@ -19,7 +19,7 @@ ___
 #### Setting Up a VM ####
 The easiest (and recommended) way to start working on (or using) CrashMonkey is to setup a virtual machine and run everything in the VM. This is partly so that any bugs in the kernel module don't bring down your whole system and partly because it is easier. Take a look at our [VM setup guide](vmsetup.md) to get started.
 
- **CrashMonkey is known to work on kernel versions 3.13.0-121-generic, 4.4.0-62-generic, 4.15.0-041500-generic, and 4.16.0-041600rc7-generic.**
+ **CrashMonkey is known to work on kernel versions 3.13.0-121-generic, 4.4.0-62-generic, 4.9.0-040900rc8-generic, 4.15.0-041500-generic, and 4.16.0-041600rc7-generic.**
 
 #### Dependencies and Build ####
 Before you begin compilation, ensure you have satisfied all dependencies mentioned in the [setup guide](../README.md/#setup)


### PR DESCRIPTION
Offically tested on 4.9-rc8 installed on Ubuntu 18.04 LTS.

Some test failures are reported when running seq1 workloads with xfsMonkey,
but I have not investigated these in depth. However, they do not appear common
enough to point to a major flaw in the port.