### PR TITLE
Port CrashMonkey to 4.14 series kernels

### DIFF
--- a/code/bio_alias.h
+++ b/code/bio_alias.h
@@ -58,7 +58,7 @@
 #define BIO_DISCARD_FLAG        REQ_OP_DISCARD
 #define BIO_IS_WRITE(bio)       op_is_write(bio_op(bio))
 
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) \
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) \
   && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
 
 #define BI_RW                   bi_opf

--- a/code/disk_wrapper.c
+++ b/code/disk_wrapper.c
@@ -819,7 +819,7 @@ static int __init disk_wrapper_init(void) {
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)) || \
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
-  // Field not present in kernel 4.15+.
+  // Field not present in kernel 4.9+.
   flush_flags = flags_device->bd_queue->flush_flags;
 #endif
   queue_flags = flags_device->bd_queue->queue_flags;

--- a/code/disk_wrapper.c
+++ b/code/disk_wrapper.c
@@ -59,7 +59,7 @@ static struct hwm_device {
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0))
   struct block_device* target_dev;
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
   struct gendisk* target_dev;
   u8 target_partno;
@@ -463,7 +463,7 @@ static unsigned long long convert_flags(unsigned long long flags) {
   }
 
 
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) \
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) \
     && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
 
   if ((flags & REQ_OP_MASK) == REQ_OP_WRITE) {
@@ -539,14 +539,15 @@ static bool should_log(struct bio *bio) {
      (bio_op(bio) == REQ_OP_FLUSH) || (bio_op(bio) == REQ_OP_WRITE) ||
      (bio_op(bio) == REQ_OP_DISCARD) || (bio_op(bio) == REQ_OP_SECURE_ERASE) ||
      (bio_op(bio) == REQ_OP_WRITE_SAME) || (bio_flags(bio) & BIO_DISCARD_FLAG));
-#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) \
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) \
     && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0))
-  // Other REQ_OP_xx functions are odd numbers, meaning they set the
-  // REQ_OP_WRITE bit which we already check for (ex. REQ_OP_WRITE_SAME = 7).
   return
     ((bio->BI_RW & REQ_FUA) || (bio->BI_RW & REQ_PREFLUSH) ||
-     (bio->BI_RW & REQ_OP_FLUSH) || (bio->BI_RW & REQ_OP_WRITE) ||
-     (bio->BI_RW & BIO_DISCARD_FLAG));
+     (bio->BI_RW & REQ_OP_FLUSH) || (bio_op(bio) == REQ_OP_WRITE) ||
+     (bio_op(bio) == BIO_DISCARD_FLAG) ||
+     (bio_op(bio) == REQ_OP_SECURE_ERASE) ||
+     (bio_op(bio) == REQ_OP_WRITE_SAME) ||
+     (bio_op(bio) == REQ_OP_WRITE_ZEROES));
 #else
 #error "Unsupported kernel version: CrashMonkey has not been tested with " \
   "your kernel version."
@@ -589,7 +590,7 @@ static void print_rw_flags(unsigned long rw, unsigned long flags) {
 static void disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)) || \
-  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0))
 static blk_qc_t disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
 #else
@@ -707,7 +708,7 @@ static blk_qc_t disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
   bio->bi_bdev = hwm->target_dev;
   submit_bio(bio);
   return BLK_QC_T_NONE;
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
   bio->bi_disk = hwm->target_dev;
   bio->bi_partno = hwm->target_partno;
@@ -790,7 +791,7 @@ static int __init disk_wrapper_init(void) {
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0))
   Device.target_dev = target_device;
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
   Device.target_dev = target_device->bd_disk;
   Device.target_partno = target_device->bd_partno;
@@ -897,7 +898,7 @@ static void __exit hello_cleanup(void) {
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0))
   blkdev_put(Device.target_dev, FMODE_READ);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0) && \
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
   blkdev_put(Device.target_bd, FMODE_READ);
 #else

--- a/docs/porting.txt
+++ b/docs/porting.txt
@@ -1,0 +1,40 @@
+Document containing quick notes about changes made to port CrashMonkey to
+different kernel versions. If no specific kernel version is mentioned in a
+comment about changes, then the kernel being compared to is the previous kernel
+CrashMonkey was available on.
+
+~~ 3.12 ~~
+* No changes from 3.13 kernels in this respect
+
+~~ 3.13 ~~
+* Original version of CrashMonkey
+
+~~ 3.16 ~~
+* Move size and sector of data writes to bio iter instead of bio
+* Change to how bio segments are iterated over
+* Minor changes to flags in bio.bi_rw
+
+~~ 4.1 ~~
+* Minor changes to flags in bio.bi_rw
+
+~~ 4.4 ~~
+* Change in-kernel function calls to mark bios as done or having an error
+
+~~ 4.9 ~~
+* Change name of bio.bi_rw field to bio.bi_opf
+* Minor changes to flags and their helper methods in bio.bi_opf
+* Change return type of function that processes bios
+* Change in-kernel submit_bio function arguments
+* Remove request_queue.flush_flags field
+
+~~ 4.14 ~~
+* Reverse order of bit-fields in bio.bi_opf (actually made in 4.10)
+* Minor changes to flags and their helper methods in bio.bi_opf
+* Change name and type of disk and partition a bio should be routed to
+      (contained in old bi.bi_bdev field)
+
+~~ 4.15 ~~
+* No changes from 4.14 kernels in this respect
+
+~~ 4.16 ~~
+* Change kobj retrieval in cow_brd.c:brd_probe


### PR DESCRIPTION
Tested on 4.14.35-041435-generic installed on Ubuntu 18.04.

Some test failures are reported when running seq1 workloads with xfsMonkey,
but I have not investigated these in depth. However, they do not appear common
enough to point to a major flaw in the port.

Furthermore, this was tested on a 4.15 installation and the results of the ported
version did not differ from the results of an un-ported version run on the 4.15
machine.