### PR TITLE
Added ACE adapter for XFSTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ CrashMonkey is a file-system agnostic record-replay-and-test framework. Unlike e
 
 
 ### Automatic Crash Explorer (Ace) ###
-Ace is an automatic workload generator, that exhaustively generates sequences of file-system operations (workloads), given certain bounds. Ace consists of a workload synthesizer that generates workloads in a high-level language which we call J-lang. A CrashMonkey adapter, that we built, converts these workloads into C++ test files that CrashMonkey can work with. More details on the current bounds imposed by Ace, and guidelines on workload generation can be found [here](docs/Ace.md).
+Ace is an automatic workload generator, that exhaustively generates sequences of file-system operations (workloads), given certain bounds. Ace consists of a workload synthesizer that generates workloads in a high-level language which we call J-lang. A CrashMonkey adapter, that we built, converts these workloads into C++ test files that CrashMonkey can work with. We also have an XFSTest adapter that allows us to convert workloads into bash scripts to be used with [xfstest](https://github.com/kdave/xfstests). More details on the current bounds imposed by Ace and guidelines on workload generation can be found [here](docs/Ace.md).
 
 CrashMonkey and Ace can be used out of the box on any Linux filesystem that implements POSIX API. Our tools have been tested to work with ext2, ext3, ext4, xfs, F2FS, and btrfs, across Linux kernel versions - 3.12, 3.13, 3.16, 4.1, 4.4, 4.15, and 4.16.
 

--- a/ace/.gitignore
+++ b/ace/.gitignore
@@ -1,0 +1,2 @@
+Makefile
+j-lang10

--- a/ace/ace.py
+++ b/ace/ace.py
@@ -1251,7 +1251,7 @@ def doPermutation(perm, test_type):
             if test_type == 'crashmonkey':
                 exec_command = 'python2 cmAdapter.py -b ../code/tests/' + dest_dir + '/base.cpp -t ' + j_lang_file + ' -p ../code/tests/' + dest_dir + '/ -o ' + str(global_count)
             elif test_type == 'xfstest':
-                exec_command = 'python2 xfstestAdapter.py -b base_xfstest.sh -t ' + j_lang_file + ' -p ../code/tests/' + dest_dir + '/ -n ' + str(global_count)
+                exec_command = 'python2 xfstestAdapter.py -b base_xfstest.sh -t ' + j_lang_file + ' -p ../code/tests/' + dest_dir + '/ -n ' + str(global_count) + " -f generic"
             subprocess.call(exec_command, shell=True)
 
 

--- a/ace/ace.py
+++ b/ace/ace.py
@@ -241,6 +241,7 @@ def build_parser():
     parser.add_argument('--sequence_len', '-l', default='3', help='Number of critical ops in the bugy workload')
     parser.add_argument('--nested', '-n', default='False', help='Add an extra level of nesting?')
     parser.add_argument('--demo', '-d', default='False', help='Create a demo workload set?')
+    parser.add_argument('--test-type', '-t', default='crashmonkey', required=False, help='Type of test to generate <crashmonkey/xfstest>. (Default: crashmonkey)')
 
     return parser
 
@@ -251,6 +252,7 @@ def print_setup(parsed_args):
     print '{0:20}  {1}'.format('Sequence length', parsed_args.sequence_len)
     print '{0:20}  {1}'.format('Nested', parsed_args.nested)
     print '{0:20}  {1}'.format('Demo', parsed_args.demo)
+    print '{0:20}  {1}'.format('Test Type', parsed_args.test_type)
     print '\n', '='*48, '\n'
 
 
@@ -1047,7 +1049,7 @@ def buildJlang(op_list, length_map):
 
 
 # Main function that exhaustively generates combinations of ops.
-def doPermutation(perm):
+def doPermutation(perm, test_type):
     
     global global_count
     global parameterList
@@ -1246,7 +1248,10 @@ def doPermutation(perm):
 
             f.close()
 
-            exec_command = 'python cmAdapter.py -b ../code/tests/' + dest_dir + '/base.cpp -t ' + j_lang_file + ' -p ../code/tests/' + dest_dir + '/ -o ' + str(global_count)
+            if test_type == 'crashmonkey':
+                exec_command = 'python2 cmAdapter.py -b ../code/tests/' + dest_dir + '/base.cpp -t ' + j_lang_file + ' -p ../code/tests/' + dest_dir + '/ -o ' + str(global_count)
+            elif test_type == 'xfstest':
+                exec_command = 'python2 xfstestAdapter.py -b base_xfstest.sh -t ' + j_lang_file + ' -p ../code/tests/' + dest_dir + '/ -n ' + str(global_count)
             subprocess.call(exec_command, shell=True)
 
 
@@ -1304,6 +1309,7 @@ def main():
     print_setup(parsed_args)
 
     num_ops = parsed_args.sequence_len
+    test_type = parsed_args.test_type
     
     if parsed_args.nested == ('True' or 'true'):
         nested = True
@@ -1420,7 +1426,7 @@ def main():
 
     bar.start()
     for i in itertools.product(OperationSet, repeat=int(num_ops)):
-        doPermutation(i)
+        doPermutation(i, test_type)
         bar.next()
 
 

--- a/ace/base_xfstest.sh
+++ b/ace/base_xfstest.sh
@@ -49,8 +49,6 @@ _init_flakey
 
 stat_opt='-c  %n - blocks: %b size: %s inode: %i links: %h'
 
-prepend() { while read line; do echo "$1$line"; done }
-
 # Rename wraps 'mv' except that 'rename A/ B/' 
 # would replace B, instead of creating A/B
 rename() { 
@@ -86,8 +84,8 @@ general_stat() {
 			# Directory with metadata and data
 			echo "Directory Metadata"
 			stat "$stat_opt" "$file"
-			echo "Directory Metadata + Child Metadata"
-			[[ -z "$(ls -A $file)" ]] || ls -1 "$file" | sort | prepend "$file/" | xargs stat "$stat_opt"
+			echo "Directory Data"
+			[[ -z "$(ls -A $file)" ]] || ls -1 "$file" | sort
 		else
 			# File with metadata and data
 			echo "File Metadata"

--- a/ace/base_xfstest.sh
+++ b/ace/base_xfstest.sh
@@ -37,7 +37,7 @@ fssize=$((2**20 * 256))
 rm -f $seqres.full
 
 # real QA test starts here
-_supported_fs generic
+_supported_fs $FILESYSTEM_TYPE
 _supported_os Linux
 _require_scratch_nocheck
 _require_dm_target flakey

--- a/ace/base_xfstest.sh
+++ b/ace/base_xfstest.sh
@@ -51,6 +51,13 @@ stat_opt='-c  %n - blocks: %b size: %s inode: %i links: %h'
 
 prepend() { while read line; do echo "$1$line"; done }
 
+# Rename wraps 'mv' except that 'rename A/ B/' 
+# would replace B, instead of creating A/B
+rename() { 
+    [ -d $1 ] && [ -d $2 ] && rm -rf $2
+    mv $1 $2
+}
+
 # Usage: general_stat [--data-only] file1 [file2] [file3 ...]
 # If the --data-only flag is passed then only the files' data
 # will be printed. This is to be used to verify fdatasync calls.

--- a/ace/base_xfstest.sh
+++ b/ace/base_xfstest.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) $CURRENT_YEAR The University of Texas at Austin.  All Rights Reserved.
+#
+# FS QA Test $TEST_NUMBER
+#
+# Test case created by CrashMonkey
+#
+# Test if we create a hard link to a file and persist either of the files, all
+# the names persist.
+#
+seq=`basename $0`
+seqres=$RESULT_DIR/$seq
+echo "QA output created by $seq"
+
+here=`pwd`
+tmp=/tmp/$$
+status=1	# failure is the default!
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_cleanup()
+{
+	_cleanup_flakey
+	cd /
+	rm -f $tmp.*
+}
+
+# get standard environment, filters and checks
+. ./common/rc
+. ./common/filter
+. ./common/dmflakey
+
+# 256MB in byte
+fssize=$((2**20 * 256))
+
+# remove previous $seqres.full before test
+rm -f $seqres.full
+
+# real QA test starts here
+_supported_fs generic
+_supported_os Linux
+_require_scratch_nocheck
+_require_dm_target flakey
+
+# initialize scratch device
+_scratch_mkfs_sized $fssize >> $seqres.full 2>&1
+_require_metadata_journaling $SCRATCH_DEV
+_init_flakey
+
+stat_opt='-c  %n - blocks: %b size: %s inode: %i links: %h'
+
+prepend() { while read line; do echo "$1$line"; done }
+
+# Usage: general_stat [--data-only] file1 [file2] [file3 ...]
+# If the --data-only flag is passed then only the files' data
+# will be printed. This is to be used to verify fdatasync calls.
+general_stat() {
+	# Parse --data-only flag
+	if [ "$1" = "--data-only" ]; then 
+		data_only="true" ; shift
+	else 
+		data_only="false"
+	fi
+
+	for file in "$@"
+	do
+		echo "-- $file --"
+		if [ ! -f "$file" ] && [ ! -d "$file" ]; then
+			echo "Doesn't exist!"
+		elif [ "$data_only" = "true" ] && [ -d "$file" ]; then
+			# Directory with --data-only
+			echo "Directory Data"
+			[[ -z "$(ls -A $file)" ]] || ls -1 "$file" | sort
+		elif [ "$data_only" = "true" ]; then
+			# File with --data-only
+			echo "File Data"
+			od "$file"
+		elif [ -d "$file" ]; then
+			# Directory with metadata and data
+			echo "Directory Metadata"
+			stat "$stat_opt" "$file"
+			echo "Directory Metadata + Child Metadata"
+			[[ -z "$(ls -A $file)" ]] || ls -1 "$file" | sort | prepend "$file/" | xargs stat "$stat_opt"
+		else
+			# File with metadata and data
+			echo "File Metadata"
+			stat "$stat_opt" "$file"
+			echo "File Data"
+			od "$file"
+		fi
+	done
+}
+
+# Open a file with O_DIRECT and write a byte into a range
+_dwrite_byte() {
+	local pattern="$1"
+	local offset="$2"
+	local len="$3"
+	local file="$4"
+	local xfs_io_args="$5"
+
+	$XFS_IO_PROG $xfs_io_args -f -c "open -f -d -s $file" -c "pwrite -S $pattern $offset $len" "$file"
+}
+
+_mwrite_byte_and_msync() {
+	local pattern="$1"
+	local offset="$2"
+	local len="$3"
+	local mmap_len="$4"
+	local file="$5"
+
+	$XFS_IO_PROG -f -c "mmap -rw 0 $mmap_len" -c "mwrite -S $pattern $offset $len" "$file" -c "msync -s"
+}
+check_consistency()
+{
+	before=$(general_stat "$@")
+	_flakey_drop_and_remount
+	after=$(general_stat "$@")
+
+	if [ "$before" != "$after" ]; then
+		echo -e "Before:\n$before"
+		echo -e "After:\n$after"
+	fi
+}
+
+# Using _scratch_mkfs instead of cleaning up the  working directory,
+# adds about 10 seconds of delay in total for the 37 tests.
+clean_dir()
+{
+	rm -rf $(find $SCRATCH_MNT/* | grep -v "lost+found")
+	sync
+	_unmount_flakey
+}
+
+# Test cases
+
+# Success, all done
+echo "Silence is golden"
+status=0
+exit

--- a/ace/base_xfstest.sh
+++ b/ace/base_xfstest.sh
@@ -56,43 +56,46 @@ rename() {
     mv $1 $2
 }
 
-# Usage: general_stat [--data-only] file1 [file2] [file3 ...]
-# If the --data-only flag is passed then only the files' data
-# will be printed. This is to be used to verify fdatasync calls.
+# Usage: general_stat [--data-only] file1 [--data-only] [file2] ..
+# If the --data-only flag precedes a file, then only that file's
+# data will be printed.
 general_stat() {
-	# Parse --data-only flag
-	if [ "$1" = "--data-only" ]; then 
-		data_only="true" ; shift
-	else 
-		data_only="false"
-	fi
-
-	for file in "$@"
-	do
-		echo "-- $file --"
-		if [ ! -f "$file" ] && [ ! -d "$file" ]; then
-			echo "Doesn't exist!"
-		elif [ "$data_only" = "true" ] && [ -d "$file" ]; then
-			# Directory with --data-only
-			echo "Directory Data"
-			[[ -z "$(ls -A $file)" ]] || ls -1 "$file" | sort
-		elif [ "$data_only" = "true" ]; then
-			# File with --data-only
-			echo "File Data"
-			od "$file"
-		elif [ -d "$file" ]; then
-			# Directory with metadata and data
-			echo "Directory Metadata"
-			stat "$stat_opt" "$file"
-			echo "Directory Data"
-			[[ -z "$(ls -A $file)" ]] || ls -1 "$file" | sort
-		else
-			# File with metadata and data
-			echo "File Metadata"
-			stat "$stat_opt" "$file"
-			echo "File Data"
-			od "$file"
-		fi
+    data_only="false"
+    while (( "$#" )); do
+        case $1 in
+            --data-only)
+                data_only="true"
+                ;;
+            *)
+                local file="$1"
+                echo "-- $file --"
+                if [ ! -f "$file" ] && [ ! -d "$file" ]; then
+                    echo "Doesn't exist!"
+                elif [ "$data_only" = "true" ] && [ -d "$file" ]; then
+                    # Directory with --data-only
+                    echo "Directory Data"
+                    [[ -z "$(ls -A $file)" ]] || ls -1 "$file" | sort
+                elif [ "$data_only" = "true" ]; then
+                    # File with --data-only
+                    echo "File Data"
+                    od "$file"
+                elif [ -d "$file" ]; then
+                    # Directory with metadata and data
+                    echo "Directory Metadata"
+                    stat "$stat_opt" "$file"
+                    echo "Directory Data"
+                    [[ -z "$(ls -A $file)" ]] || ls -1 "$file" | sort
+                else
+                    # File with metadata and data
+                    echo "File Metadata"
+                    stat "$stat_opt" "$file"
+                    echo "File Data"
+                    od "$file"
+                fi
+                data_only="false"
+                ;;
+        esac
+        shift
 	done
 }
 

--- a/ace/xfstestAdapter.py
+++ b/ace/xfstestAdapter.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
 
-# To run : python xfstestAdapter.py -b base_xfstest.sh -t code/tests/generic_039/generic_039 -p code/tests/generic_039 -o 039
+# To run : python xfstestAdapter.py -b base_xfstest.sh -t <jlang-file> \
+#               -p <output_directory> -n <test_number>
+#
+# For example, with output_directory = "output" and test_number = "001",
+# the converted test files will be located at:
+#   - output/001
+#   - output/001.out
+
 import os
 import re
 import sys

--- a/ace/xfstestAdapter.py
+++ b/ace/xfstestAdapter.py
@@ -103,7 +103,7 @@ def create_dir(dir_path):
     except OSError:
         if not os.path.isdir(dir_path):
             raise
-def translate_link(line, method):
+def translate_link(line):
     parts = line.split(" ")
     assert parts[0] == "link"
     assert len(parts) == 3, "Must have 2 args. Usage: link <src> <target>."
@@ -112,7 +112,7 @@ def translate_link(line, method):
     src, target = translate_filename(src), translate_filename(target)
     return ["ln {} {}".format(src, target)]
 
-def translate_symlink(line, method):
+def translate_symlink(line):
     parts = line.split(" ")
     assert parts[0] == "symlink"
     assert len(parts) == 3, "Must have 2 args. Usage: symlink <src> <target>."
@@ -121,7 +121,7 @@ def translate_symlink(line, method):
     src, target = translate_filename(src), translate_filename(target)
     return ["ln -s {} {}".format(src, target)]
 
-def translate_remove(line, method):
+def translate_remove(line):
     parts = line.split(" ")
     assert parts[0] == "remove" or parts[0] == "unlink"
     assert len(parts) == 2, "Must have 1 arg. Usage: remove/unlink <filename>."
@@ -131,7 +131,7 @@ def translate_remove(line, method):
 
     return ["rm {}".format(filename)]
 
-def translate_fsetxattr(line, method):
+def translate_fsetxattr(line):
     parts = line.split(" ")
     assert parts[0] == "fsetxattr"
     assert len(parts) == 2, "Must have 1 arg. Usage: fsetxattr <filename>."
@@ -142,7 +142,7 @@ def translate_fsetxattr(line, method):
     return ["attr -s {} -V {} {} > /dev/null".format(FILE_ATTR_KEY,
         FILE_ATTR_VALUE, filename)]
 
-def translate_removexattr(line, method):
+def translate_removexattr(line):
     parts = line.split(" ")
     assert parts[0] == "removexattr"
     assert len(parts) == 2, "Must have 1 arg. Usage: removexattr <filename>."
@@ -152,7 +152,7 @@ def translate_removexattr(line, method):
 
     return ["attr -r {} {}".format(FILE_ATTR_KEY, filename)]
 
-def translate_truncate(line, method):
+def translate_truncate(line):
     parts = line.split(" ")
     assert parts[0] == "truncate"
     assert len(parts) == 3, "Must have 2 args. Usage: truncate <filename> <new size>."
@@ -162,7 +162,7 @@ def translate_truncate(line, method):
 
     return ["truncate {} -s {}".format(filename, size)]
 
-def translate_dwrite(line, method):
+def translate_dwrite(line):
     parts = line.split(" ")
     assert parts[0] == "dwrite"
     assert len(parts) == 4, "Must have 3 args. Usage: dwrite <filename> <offset> <size>"
@@ -177,7 +177,7 @@ def translate_dwrite(line, method):
         size,
         filename)]
 
-def translate_write(line, method):
+def translate_write(line):
     parts = line.split(" ")
     assert parts[0] == "write"
     assert len(parts) == 4, "Must have 3 args. Usage: write <filename> <offset> <size>"
@@ -192,7 +192,7 @@ def translate_write(line, method):
         size,
         filename)]
 
-def translate_mmapwrite(line, method):
+def translate_mmapwrite(line):
     parts = line.split(" ")
     assert parts[0] == "mmapwrite"
     assert len(parts) == 4, "Must have 3 args. Usage: mmapwrite <filename> <offset> <size>"
@@ -216,7 +216,7 @@ def translate_mmapwrite(line, method):
                 filename),
             "check_consistency {}".format(filename)]
 
-def translate_open(line, method):
+def translate_open(line):
     parts = line.split(" ")
     assert parts[0] == "open"
     assert len(parts) == 4, "Must have 3 args. Usage: open <filename> <flags> <mode>."
@@ -231,7 +231,7 @@ def translate_open(line, method):
     return ["touch {}".format(filename), 
             "chmod {} {}".format(mode, filename)]
 
-def translate_mkdir(line, method):
+def translate_mkdir(line):
     parts = line.split(" ")
     assert parts[0] == "mkdir"
     assert len(parts) == 3, "Must have 2 args. Usage: mkdir <directory> <mode>."
@@ -240,7 +240,7 @@ def translate_mkdir(line, method):
     filename = translate_filename(filename)
     return ["mkdir {} -p -m {}".format(filename, umask)]
 
-def translate_opendir(line, method):
+def translate_opendir(line):
     parts = line.split(" ")
     assert parts[0] == "opendir"
     assert len(parts) == 3, "Must have 2 args. Usage: opendir <directory> <mode>."
@@ -249,7 +249,7 @@ def translate_opendir(line, method):
     filename = translate_filename(filename)
     return ["mkdir {} -p -m {}".format(filename, umask)]
 
-def translate_fsync(line, method):
+def translate_fsync(line):
     parts = line.split(" ")
     assert parts[0] == "fsync"
     assert len(parts) == 2, "Must have 1 arg. Usage: fsync <file or directory>."
@@ -259,7 +259,7 @@ def translate_fsync(line, method):
     return ["$XFS_IO_PROG -c \"fsync\" {}".format(filename),
             "check_consistency {}".format(filename)]
 
-def translate_fdatasync(line, method):
+def translate_fdatasync(line):
     parts = line.split(" ")
     assert parts[0] == "fdatasync"
     assert len(parts) == 2, "Must have 1 arg. Usage: fdatasync <file or directory>."
@@ -269,7 +269,7 @@ def translate_fdatasync(line, method):
     return ["$XFS_IO_PROG -c \"fdatasync\" {}".format(filename),
             "check_consistency --data-only {}".format(filename)]
 
-def translate_sync(line, method):
+def translate_sync(line):
     parts = line.split(" ")
     assert parts[0] == "sync"
     assert len(parts) == 1, "sync does not allow any arguments"
@@ -277,7 +277,7 @@ def translate_sync(line, method):
     return ["sync", "check_consistency " + " ".join(used_files)]
 
 
-def translate_rename(line, method):
+def translate_rename(line):
     parts = line.split(" ")
     assert parts[0] == "rename"
     assert len(parts) == 3, "Must have 2 args. Usage: rename <old name> <new name>."
@@ -285,9 +285,9 @@ def translate_rename(line, method):
     old, new = parts[1:]
     old, new = translate_filename(old), translate_filename(new)
 
-    return ["mv {} {}".format(old, new)]
+    return ["rename {} {}".format(old, new)]
 
-def translate_rmdir(line, method):
+def translate_rmdir(line):
     parts = line.split(" ")
     assert parts[0] == "rmdir"
     assert len(parts) == 2, "Must have 1 arg. Usage: rmdir <directory>."
@@ -297,7 +297,7 @@ def translate_rmdir(line, method):
 
     return ["rm -rf {}".format(directory)]
 
-def translate_falloc(line, method):
+def translate_falloc(line):
     parts = line.split(" ")
     assert parts[0] == "falloc"
     assert len(parts) == 5, "Must have 4 args. Usage: falloc <file> <mode> <offset> <length>."
@@ -309,57 +309,57 @@ def translate_falloc(line, method):
 
 # Translate a line of the high-level j-lang language
 # into a list of lines of bash for xfstest
-def translate_functions(line, method):
+def translate_functions(line):
     # Note that order is important here. Commands that are
     # prefixes of each other, i.e. open and opendir, must
     # have the longer string appear first.
 
     if line.startswith("mkdir"):
-        return translate_mkdir(line, method)
+        return translate_mkdir(line)
     elif line.startswith("opendir"):
-        return translate_opendir(line, method)
+        return translate_opendir(line)
     elif line.startswith("open"):
-        return translate_open(line, method)
+        return translate_open(line)
     elif line.startswith("fsync"):
-        return translate_fsync(line, method)
+        return translate_fsync(line)
     elif line.startswith("fdatasync"):
-        return translate_fdatasync(line, method)
+        return translate_fdatasync(line)
     elif line.startswith("sync"):
-        return translate_sync(line, method)
+        return translate_sync(line)
     elif line.startswith("rename"):
-        return translate_rename(line, method)
+        return translate_rename(line)
     elif line.startswith("falloc"):
-        return translate_falloc(line, method)
+        return translate_falloc(line)
     elif line.startswith("close"):
         return []
     elif line.startswith("rmdir"):
-        return translate_rmdir(line, method)
+        return translate_rmdir(line)
     elif line.startswith("truncate"):
-        return translate_truncate(line, method)
+        return translate_truncate(line)
     elif line.startswith("checkpoint"):
         return []
     elif line.startswith("fsetxattr"):
-        return translate_fsetxattr(line, method)
+        return translate_fsetxattr(line)
     elif line.startswith("removexattr"):
-        return translate_removexattr(line, method)
+        return translate_removexattr(line)
     elif line.startswith("remove"):
-        return translate_remove(line, method)
+        return translate_remove(line)
     elif line.startswith("unlink"):
-        return translate_remove(line, method)
+        return translate_remove(line)
     elif line.startswith("link"):
-        return translate_link(line, method)
+        return translate_link(line)
     elif line.startswith("symlink"):
-        return translate_symlink(line, method)
+        return translate_symlink(line)
     elif line.startswith("dwrite"):
-        return translate_dwrite(line, method)
+        return translate_dwrite(line)
     elif line.startswith("mmapwrite"):
-        return translate_mmapwrite(line, method)
+        return translate_mmapwrite(line)
     elif line.startswith("write"):
-        return translate_write(line, method)
+        return translate_write(line)
     elif line.startswith("none"):
         return []
     else:
-        raise ValueError("Unknown function", method, line)
+        raise ValueError("Unknown function", line)
 
 def main():
     # Parse input args
@@ -404,12 +404,11 @@ def main():
         base_contents = f.readlines()
         base_contents = list(map(filter_line, base_contents))
         test_cases_index = base_contents.index("# Test cases\n") + 1
-    f.close()
 
     copyfile(base_file, generated_test)
 
-    # Iterate through test file and create list of lines to add
-    lines_to_add = ["_mount_flakey"]
+    # Iterate through test file and get lines to translate.
+    lines_to_translate = []
     with open(test_file, 'r') as f:
         for line in f:
             # Ignore newlines
@@ -423,18 +422,16 @@ def main():
             # base file to populate so save it and skip this line
             if line.split(' ')[0] == '#' :
                 method = line.strip().split()[-1]
-                continue
-            
-            if method in ['declare', 'define']:
-                continue
-
             elif method in ['setup', 'run']: 
-                lines_to_add.extend(translate_functions(line, method))
-                #insertFunctions(line, new_file, new_index_map, method)
-    f.close()
+                lines_to_translate.append(line)
+
+    # Translate lines into xfstest cformat.
+    lines_to_add = ["_mount_flakey"]
+    for line in lines_to_translate:
+        lines_to_add.extend(translate_functions(line))
     lines_to_add.append("clean_dir")
 
-    # Write output files
+    # Insert lines into relevant location and write output files.
     lines_to_add = list(map(lambda x: x + "\n", lines_to_add))
     output_contents = base_contents[:test_cases_index] + lines_to_add + base_contents[test_cases_index:]
     with open(generated_test, 'w+') as f:

--- a/ace/xfstestAdapter.py
+++ b/ace/xfstestAdapter.py
@@ -425,7 +425,7 @@ def main():
             elif method in ['setup', 'run']: 
                 lines_to_translate.append(line)
 
-    # Translate lines into xfstest cformat.
+    # Translate lines into xfstest format.
     lines_to_add = ["_mount_flakey"]
     for line in lines_to_translate:
         lines_to_add.extend(translate_functions(line))

--- a/ace/xfstestAdapter.py
+++ b/ace/xfstestAdapter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # To run : python xfstestAdapter.py -b base_xfstest.sh -t <jlang-file> \
-#               -p <output_directory> -n <test_number>
+#               -p <output_directory> -n <test_number> -f <filesystem type>
 #
 # For example, with output_directory = "output" and test_number = "001",
 # the converted test files will be located at:
@@ -101,6 +101,7 @@ def build_parser():
     parser.add_argument('--target_path', '-p', required=True, help='Directory to save the generated test files')
 
     parser.add_argument('--test_number', '-n', required=True, help='The test number following xfstest convention. Will generate <test_number> and <test_number>.out')
+    parser.add_argument('--filesystem_type', '-f', required=True, help='The filesystem type for the test (i.e. generic, ext4, btrfs, xfs, f2fs, etc.)')
     return parser
 
 
@@ -111,6 +112,7 @@ def print_setup(parsed_args):
     print '{0:20}  {1}'.format('Test skeleton', parsed_args.test_file)
     print '{0:20}  {1}'.format('Target directory', parsed_args.target_path)
     print '{0:20}  {1}'.format('Test number', parsed_args.test_number)
+    print '{0:20}  {1}'.format('Filesystem type', parsed_args.filesystem_type)
     print '\n', '='*48, '\n'
     
 
@@ -561,12 +563,14 @@ def main():
     base_file = parsed_args.base_file
     test_file = parsed_args.test_file
     test_number = parsed_args.test_number
+    filesystem_type = parsed_args.filesystem_type
     generated_test = os.path.join(parsed_args.target_path, test_number)
     generated_test_output = os.path.join(parsed_args.target_path, test_number + ".out")
     
     # Template parameters and helper functions for populating the base file
     template_params = [("$CURRENT_YEAR", str(datetime.datetime.now().year)),
-                       ("$TEST_NUMBER", test_number)]
+                       ("$TEST_NUMBER", test_number),
+                       ("$FILESYSTEM_TYPE", filesystem_type)]
 
     def filter_line(line):
         for param, value in template_params:

--- a/ace/xfstestAdapter.py
+++ b/ace/xfstestAdapter.py
@@ -8,7 +8,7 @@
 #   - output/001
 #   - output/001.out
 
-import os 
+import os
 import re
 import sys
 import stat
@@ -206,7 +206,6 @@ class State():
 
         # Special case for directory renames: 
         # If we rename A -> B, we must rename Afoo -> Bfoo
-        # TODO: Generalize this case.
         jlang_old, jlang_new = get_row_from_filename(old)[0], get_row_from_filename(new)[0]
 
         dirs = ["A", "B", "AC"]

--- a/ace/xfstestAdapter.py
+++ b/ace/xfstestAdapter.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python
+
+# To run : python xfstestAdapter.py -b base_xfstest.sh -t code/tests/generic_039/generic_039 -p code/tests/generic_039 -o 039
+import os
+import re
+import sys
+import stat
+import subprocess
+import argparse
+import time
+import datetime
+import itertools
+from shutil import copyfile
+from string import maketrans
+
+
+# All functions that has options go here
+FallocOptions = {
+    '0'                                       : '$XFS_IO_PROG -f -c \"falloc {offset} {length}\" {filename}',
+    'FALLOC_FL_KEEP_SIZE'                     : '$XFS_IO_PROG -f -c \"falloc -k {offset} {length}\" {filename}',
+    'FALLOC_FL_ZERO_RANGE'                    : '$XFS_IO_PROG -f -c \"fzero {offset} {length}\" {filename}',
+    'FALLOC_FL_ZERO_RANGE|FALLOC_FL_KEEP_SIZE': '$XFS_IO_PROG -f -c \"fzero -k {offset} {length}\" {filename}',
+    'FALLOC_FL_PUNCH_HOLE|FALLOC_FL_KEEP_SIZE': '$XFS_IO_PROG -f -c \"fpunch {offset} {length}\" {filename}'
+}
+
+FsyncOptions = ['fsync','fdatasync']
+
+RemoveOptions = ['remove','unlink']
+
+LinkOptions = ['link','symlink']
+
+WriteOptions = ['WriteData','WriteDataMmap', 'pwrite']
+
+# Constants
+FILE_ATTR_KEY = "user.xattr1"
+FILE_ATTR_VALUE = "val1"
+WRITE_VALUE = "0x22"
+MMAPWRITE_VALUE = "0x33"
+DWRITE_VALUE = "0x44"
+
+# Because the filenaming convention in the high-level j-lang language 
+# seems to be arbitrary, we hard code the translation here to ensure
+# that any inconsistency will raise a clear, easy-to-debug error.
+jlang_files_to_xfs = {
+    "test"  : "test"   ,
+    "A"     : "A"      ,
+    "AC"    : "A/C"    ,
+    "B"     : "B"      ,
+    "foo"   : "foo"    , 
+    "bar"   : "bar"    ,
+    "Afoo"  : "A/foo"  , 
+    "Abar"  : "A/bar"  ,
+    "Bfoo"  : "B/foo"  , 
+    "Bbar"  : "B/bar"  ,
+    "ACfoo" : "A/C/foo",
+    "ACbar" : "A/C/bar"
+}
+
+used_files = set()
+
+def translate_filename(filename):
+    global used_files
+
+    filename = "$SCRATCH_MNT/" + jlang_files_to_xfs[filename]
+
+    used_files.add(filename)
+    return filename
+
+def build_parser():
+    parser = argparse.ArgumentParser(description='Workload Generator for XFSMonkey v1.0')
+
+    # global args
+    parser.add_argument('--base_file', '-b', required=True, help='Base test file to generate workload')
+    parser.add_argument('--test_file', '-t', required=True, help='J lang test skeleton to generate workload')
+
+    # crash monkey args
+    parser.add_argument('--target_path', '-p', required=True, help='Directory to save the generated test files')
+
+    parser.add_argument('--test_number', '-n', required=True, help='The test number following xfstest convention. Will generate <test_number> and <test_number>.out')
+    return parser
+
+
+def print_setup(parsed_args):
+    print '\n{: ^50s}'.format('XFSMonkey Workload generatorv0.1\n')
+    print '='*20, 'Setup' , '='*20, '\n'
+    print '{0:20}  {1}'.format('Base test file', parsed_args.base_file)
+    print '{0:20}  {1}'.format('Test skeleton', parsed_args.test_file)
+    print '{0:20}  {1}'.format('Target directory', parsed_args.target_path)
+    print '{0:20}  {1}'.format('Test number', parsed_args.test_number)
+    print '\n', '='*48, '\n'
+    
+
+def create_dir(dir_path):
+    try: 
+        os.makedirs(dir_path)
+    except OSError:
+        if not os.path.isdir(dir_path):
+            raise
+def translate_link(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "link"
+    assert len(parts) == 3, "Must have 2 args. Usage: link <src> <target>."
+
+    src, target = parts[1:]
+    src, target = translate_filename(src), translate_filename(target)
+    return ["ln {} {}".format(src, target)]
+
+def translate_symlink(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "symlink"
+    assert len(parts) == 3, "Must have 2 args. Usage: symlink <src> <target>."
+
+    src, target = parts[1:]
+    src, target = translate_filename(src), translate_filename(target)
+    return ["ln -s {} {}".format(src, target)]
+
+def translate_remove(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "remove" or parts[0] == "unlink"
+    assert len(parts) == 2, "Must have 1 arg. Usage: remove/unlink <filename>."
+
+    filename = parts[1]
+    filename = translate_filename(filename)
+
+    return ["rm {}".format(filename)]
+
+def translate_fsetxattr(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "fsetxattr"
+    assert len(parts) == 2, "Must have 1 arg. Usage: fsetxattr <filename>."
+
+    filename = parts[1]
+    filename = translate_filename(filename)
+
+    return ["attr -s {} -V {} {} > /dev/null".format(FILE_ATTR_KEY,
+        FILE_ATTR_VALUE, filename)]
+
+def translate_removexattr(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "removexattr"
+    assert len(parts) == 2, "Must have 1 arg. Usage: removexattr <filename>."
+
+    filename = parts[1]
+    filename = translate_filename(filename)
+
+    return ["attr -r {} {}".format(FILE_ATTR_KEY, filename)]
+
+def translate_truncate(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "truncate"
+    assert len(parts) == 3, "Must have 2 args. Usage: truncate <filename> <new size>."
+
+    filename, size = parts[1:]
+    filename = translate_filename(filename)
+
+    return ["truncate {} -s {}".format(filename, size)]
+
+def translate_dwrite(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "dwrite"
+    assert len(parts) == 4, "Must have 3 args. Usage: dwrite <filename> <offset> <size>"
+
+    filename, offset, size = parts[1:]
+    filename = translate_filename(filename)
+
+    # From common/rc in xfstest
+    return ["_dwrite_byte {} {} {} {} \"\" > /dev/null".format(
+        DWRITE_VALUE,
+        offset,
+        size,
+        filename)]
+
+def translate_write(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "write"
+    assert len(parts) == 4, "Must have 3 args. Usage: write <filename> <offset> <size>"
+
+    filename, offset, size = parts[1:]
+    filename = translate_filename(filename)
+
+    # From common/rc in xfstest
+    return ["_pwrite_byte {} {} {} {} \"\" > /dev/null".format(
+        WRITE_VALUE,
+        offset,
+        size,
+        filename)]
+
+def translate_mmapwrite(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "mmapwrite"
+    assert len(parts) == 4, "Must have 3 args. Usage: mmapwrite <filename> <offset> <size>"
+
+    filename, offset, size = parts[1:]
+    filename = translate_filename(filename)
+
+    mmap_offset = int(offset) + int(size)
+
+    # From common/rc in xfstest
+    # Calling mmapwrte to an offset that has not yet been 
+    # allocated causes a BUS_IO error.
+    return ["$XFS_IO_PROG -f -c \"falloc 0 {}\" {}".format(
+                mmap_offset,
+                filename),
+            "_mwrite_byte_and_msync {} {} {} {} {}".format(
+                MMAPWRITE_VALUE,
+                offset,
+                size,
+                mmap_offset,
+                filename),
+            "check_consistency {}".format(filename)]
+
+def translate_open(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "open"
+    assert len(parts) == 4, "Must have 3 args. Usage: open <filename> <flags> <mode>."
+
+    # If O_CREAT is not passed, it's unclear what the 
+    # 'mode' bits are for. Thus, we assume that O_CREAT
+    # will be passed.
+    filename, flags, mode = parts[1:]
+    filename = translate_filename(filename)
+    assert "O_CREAT" in flags, "flags must contain O_CREAT for open"
+
+    return ["touch {}".format(filename), 
+            "chmod {} {}".format(mode, filename)]
+
+def translate_mkdir(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "mkdir"
+    assert len(parts) == 3, "Must have 2 args. Usage: mkdir <directory> <mode>."
+
+    filename, umask = parts[1:]
+    filename = translate_filename(filename)
+    return ["mkdir {} -p -m {}".format(filename, umask)]
+
+def translate_opendir(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "opendir"
+    assert len(parts) == 3, "Must have 2 args. Usage: opendir <directory> <mode>."
+
+    filename, umask = parts[1:]
+    filename = translate_filename(filename)
+    return ["mkdir {} -p -m {}".format(filename, umask)]
+
+def translate_fsync(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "fsync"
+    assert len(parts) == 2, "Must have 1 arg. Usage: fsync <file or directory>."
+
+    filename = parts[1]
+    filename = translate_filename(filename)
+    return ["$XFS_IO_PROG -c \"fsync\" {}".format(filename),
+            "check_consistency {}".format(filename)]
+
+def translate_fdatasync(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "fdatasync"
+    assert len(parts) == 2, "Must have 1 arg. Usage: fdatasync <file or directory>."
+
+    filename = parts[1]
+    filename = translate_filename(filename)
+    return ["$XFS_IO_PROG -c \"fdatasync\" {}".format(filename),
+            "check_consistency --data-only {}".format(filename)]
+
+def translate_sync(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "sync"
+    assert len(parts) == 1, "sync does not allow any arguments"
+
+    return ["sync", "check_consistency " + " ".join(used_files)]
+
+
+def translate_rename(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "rename"
+    assert len(parts) == 3, "Must have 2 args. Usage: rename <old name> <new name>."
+
+    old, new = parts[1:]
+    old, new = translate_filename(old), translate_filename(new)
+
+    return ["mv {} {}".format(old, new)]
+
+def translate_rmdir(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "rmdir"
+    assert len(parts) == 2, "Must have 1 arg. Usage: rmdir <directory>."
+
+    directory = parts[1]
+    directory = translate_filename(directory)
+
+    return ["rm -rf {}".format(directory)]
+
+def translate_falloc(line, method):
+    parts = line.split(" ")
+    assert parts[0] == "falloc"
+    assert len(parts) == 5, "Must have 4 args. Usage: falloc <file> <mode> <offset> <length>."
+
+    filename, mode, offset, length = parts[1:]
+    filename = translate_filename(filename)
+
+    return [FallocOptions[mode].format(filename=filename, offset=offset, length=length)]
+
+# Translate a line of the high-level j-lang language
+# into a list of lines of bash for xfstest
+def translate_functions(line, method):
+    # Note that order is important here. Commands that are
+    # prefixes of each other, i.e. open and opendir, must
+    # have the longer string appear first.
+
+    if line.startswith("mkdir"):
+        return translate_mkdir(line, method)
+    elif line.startswith("opendir"):
+        return translate_opendir(line, method)
+    elif line.startswith("open"):
+        return translate_open(line, method)
+    elif line.startswith("fsync"):
+        return translate_fsync(line, method)
+    elif line.startswith("fdatasync"):
+        return translate_fdatasync(line, method)
+    elif line.startswith("sync"):
+        return translate_sync(line, method)
+    elif line.startswith("rename"):
+        return translate_rename(line, method)
+    elif line.startswith("falloc"):
+        return translate_falloc(line, method)
+    elif line.startswith("close"):
+        return []
+    elif line.startswith("rmdir"):
+        return translate_rmdir(line, method)
+    elif line.startswith("truncate"):
+        return translate_truncate(line, method)
+    elif line.startswith("checkpoint"):
+        return []
+    elif line.startswith("fsetxattr"):
+        return translate_fsetxattr(line, method)
+    elif line.startswith("removexattr"):
+        return translate_removexattr(line, method)
+    elif line.startswith("remove"):
+        return translate_remove(line, method)
+    elif line.startswith("unlink"):
+        return translate_remove(line, method)
+    elif line.startswith("link"):
+        return translate_link(line, method)
+    elif line.startswith("symlink"):
+        return translate_symlink(line, method)
+    elif line.startswith("dwrite"):
+        return translate_dwrite(line, method)
+    elif line.startswith("mmapwrite"):
+        return translate_mmapwrite(line, method)
+    elif line.startswith("write"):
+        return translate_write(line, method)
+    elif line.startswith("none"):
+        return []
+    else:
+        raise ValueError("Unknown function", method, line)
+
+def main():
+    # Parse input args
+    parsed_args = build_parser().parse_args()
+
+    # Print the test setup - just for sanity
+    #print_setup(parsed_args)
+    
+    # Check if test file exists
+    if not os.path.exists(parsed_args.test_file) or not os.path.isfile(parsed_args.test_file):
+        print parsed_args.test_file + ' : No such test file\n'
+        exit(1)
+
+    # Check that test number is a valid number/has no extension
+    if not parsed_args.test_number.isdigit():
+        print("'{}' is not a valid test number".format(parsed_args.test_number))
+        exit(1)
+    
+    # Create the target directory
+    create_dir(parsed_args.target_path)
+
+    base_file = parsed_args.base_file
+    test_file = parsed_args.test_file
+    test_number = parsed_args.test_number
+    generated_test = os.path.join(parsed_args.target_path, test_number)
+    generated_test_output = os.path.join(parsed_args.target_path, test_number + ".out")
+    
+    # Template parameters and helper functions for populating the base file
+    template_params = [("$CURRENT_YEAR", str(datetime.datetime.now().year)),
+                       ("$TEST_NUMBER", test_number)]
+
+    def filter_line(line):
+        for param, value in template_params:
+            if param in line:
+                line = line.replace(param, value)
+        return line
+
+    # Find index to insert tests cases, this region is marked by
+    # a line containing the comment '# Test cases'. Also, replace
+    # template parameters.
+    with open(base_file, 'r') as f:
+        base_contents = f.readlines()
+        base_contents = list(map(filter_line, base_contents))
+        test_cases_index = base_contents.index("# Test cases\n") + 1
+    f.close()
+
+    copyfile(base_file, generated_test)
+
+    # Iterate through test file and create list of lines to add
+    lines_to_add = ["_mount_flakey"]
+    with open(test_file, 'r') as f:
+        for line in f:
+            # Ignore newlines
+            if line.split(' ')[0] == '\n':
+                continue
+            
+            # Remove leading, trailing spaces
+            line = line.strip()
+            
+            # If the line starts with #, it indicates which region of 
+            # base file to populate so save it and skip this line
+            if line.split(' ')[0] == '#' :
+                method = line.strip().split()[-1]
+                continue
+            
+            if method in ['declare', 'define']:
+                continue
+
+            elif method in ['setup', 'run']: 
+                lines_to_add.extend(translate_functions(line, method))
+                #insertFunctions(line, new_file, new_index_map, method)
+    f.close()
+    lines_to_add.append("clean_dir")
+
+    # Write output files
+    lines_to_add = list(map(lambda x: x + "\n", lines_to_add))
+    output_contents = base_contents[:test_cases_index] + lines_to_add + base_contents[test_cases_index:]
+    with open(generated_test, 'w+') as f:
+        f.writelines(output_contents)
+
+    out_lines = ["QA output created by {}\n".format(test_number), "Silence is golden\n"]
+    with open(generated_test_output, 'w+') as f:
+        f.writelines(out_lines)
+
+if __name__ == '__main__':
+	main()

--- a/docs/Ace.md
+++ b/docs/Ace.md
@@ -65,7 +65,21 @@ check_consistency $SCRATCH_MNT/B/foo
 clean_dir
 ```
 
-The definition of `check_consistency` and `clean_dir` as well as all other helper functions can be found [here](../ace/base_xfstest.sh). For information explaining how to run the adapters directly, refer to the the beginning of the following files for [Crashmonkey](../ace/cmAdapter.py) and [xfstest](../ace/xfstestAdapter.py) respectively.
+The definition of `check_consistency` and `clean_dir` as well as all other helper functions can be found [here](../ace/base_xfstest.sh). The [XFSTest adapter](../ace/xfstestAdapter.py) itself can be run with the following required arguments:
+
+```
+--base_file BASE_FILE,             -b BASE_FILE       Base test file to generate workload
+--test_file TEST_FILE,             -t TEST_FILE       J lang test skeleton to generate workload
+--target_path TARGET_PATH,         -p TARGET_PATH     Directory to save the generated test files
+--test_number TEST_NUMBER,         -n TEST_NUMBER     The test number following xfstest convention. 
+                                                      Will generate <test_number> and <test_number>.out 
+--filesystem_type FILESYSTEM_TYPE, -f FILESYSTEM_TYPE The filesystem type for the test 
+                                                      (i.e. generic, ext4, btrfs, xfs, f2fs, etc.)
+```
+
+Note that the base file for the XFSTest adapter can be found at `../ace/base_xfstest.sh`.
+
+For more information explaining how to run the adapters directly, refer to the beginning of the following files for [Crashmonkey](../ace/cmAdapter.py) and [xfstest](../ace/xfstestAdapter.py) respectively.
 
 ---
 ### Bounds used by Ace ###

--- a/docs/Ace.md
+++ b/docs/Ace.md
@@ -12,7 +12,8 @@ checkpoint 1
 close Bfoo
 ```
 
-2. **CrashMonkey adapter** : Workloads represented in the high-level language have to be converted to a [format](workload.md) that CrashMonkey understands. This is taken care of by the adapter. For example, the above workload is converted to the run method of CrashMonkey as follows.
+1. **Workload Adapter** : Workloads represented in the high-level language have to be converted into executables that can be run and verified. We support the following two formats:
+    1. *Crashmonkey* : The Crashmonkey adapter translates the high-level language into a [format](workload.md) that CrashMonkey understands. For example, the above workload is converted to the run method of CrashMonkey as follows.
 
 ```c++
 virtual int run( int checkpoint ) override {
@@ -52,6 +53,19 @@ virtual int run( int checkpoint ) override {
     return 0;
 }
 ```
+
+2. *XFSTest* : The XFSTest adapter translates the high-level language into a test file and expected output file to be run with [xfstest](https://github.com/kdave/xfstests). For example, the above workload would be converted into the following code (excluding the xfstest initializiation and code and helper methods):
+	
+```bash
+mkdir $SCRATCH_MNT/B -p -m 0777
+touch $SCRATCH_MNT/B/foo
+chmod 0777 $SCRATCH_MNT/B/foo
+$XFS_IO_PROG -c "fsync" $SCRATCH_MNT/B/foo
+check_consistency $SCRATCH_MNT/B/foo
+clean_dir
+```
+
+The definition of `check_consistency` and `clean_dir` as well as all other helper functions can be found [here](../ace/base_xfstest.sh). For information explaining how to run the adapters directly, refer to the the beginning of the following files for [Crashmonkey](../ace/cmAdapter.py) and [xfstest](../ace/xfstestAdapter.py) respectively.
 
 ---
 ### Bounds used by Ace ###
@@ -112,6 +126,7 @@ Generating workloads with Ace is a two-step process.
       * `-l` - Sequence length of the workload, i.e., the number of core file-system operations in the workload.
       * `-n` - If True, provides an additional level of nesting to the file set. Adds a directory `A/C` and two files `A/C/foo` and `A/C/bar` to the set of files.
       * `-d` - Demo workload. If true, simply restricts the workload space to test two file-system operations `link` and `fallocate`, allowing the persistence of used files only. The file set is also restricted to just `foo` and `A/bar`
+			* `-t` - The type of test to generate. Should one of 'crashmonkey' and 'xfstest'. If unspecified, the adapter will default to 'crashmonkey'.
 
 ___
 ### Generalizing Ace ###

--- a/docs/Ace.md
+++ b/docs/Ace.md
@@ -77,7 +77,13 @@ The definition of `check_consistency` and `clean_dir` as well as all other helpe
                                                       (i.e. generic, ext4, btrfs, xfs, f2fs, etc.)
 ```
 
-Note that the base file for the XFSTest adapter can be found at `../ace/base_xfstest.sh`.
+For example, in running the following:
+
+```
+python2 xfstestAdapter.py -b ../ace/base_xfstest.sh -t <J-LANG FILE> -p output/ -n 001 -f generic
+```
+
+would create `output/001` and `output/001.out` from the given J-lang file.  Note that the base file at `../ace/base_xfstest.sh` should be used for every use of the XFSTest adapter.
 
 For more information explaining how to run the adapters directly, refer to the beginning of the following files for [Crashmonkey](../ace/cmAdapter.py) and [xfstest](../ace/xfstestAdapter.py) respectively.
 


### PR DESCRIPTION
Adds an XFSTest adapter for ACE so that we can generate test cases in the XFSTest format.

Manually verified that the below files (in which all supported instructions appear at least once) all generate valid and passing xfstests:

code/tests/seq1/j-lang-files/j-lang255 
code/tests/seq1/j-lang-files/j-lang308 
code/tests/seq1/j-lang-files/j-lang181 
code/tests/seq1/j-lang-files/j-lang37  
code/tests/seq1/j-lang-files/j-lang316 
code/tests/seq1/j-lang-files/j-lang189 
code/tests/seq1/j-lang-files/j-lang191 
code/tests/seq1/j-lang-files/j-lang94  
code/tests/seq1/j-lang-files/j-lang254 
code/tests/seq1/j-lang-files/j-lang322 
code/tests/seq1/j-lang-files/j-lang311 
code/tests/seq1/j-lang-files/j-lang168 
code/tests/seq1/j-lang-files/j-lang266 
code/tests/seq1/j-lang-files/j-lang144 
code/tests/seq1/j-lang-files/j-lang51  
code/tests/seq1/j-lang-files/j-lang240

in ace/, running:

python2 xfstestAdapter.py -b base_xfstest.sh -t <j-lang file to convert> -p <output_dir> -n 001

will create <output_dir>/001 and <output_dir>/001.out
