### PR TITLE
Port to Linux 5.5.0 - 5.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ CrashMonkey is a file-system agnostic record-replay-and-test framework. Unlike e
 ### Automatic Crash Explorer (Ace) ###
 Ace is an automatic workload generator, that exhaustively generates sequences of file-system operations (workloads), given certain bounds. Ace consists of a workload synthesizer that generates workloads in a high-level language which we call J-lang. A CrashMonkey adapter, that we built, converts these workloads into C++ test files that CrashMonkey can work with. We also have an XFSTest adapter that allows us to convert workloads into bash scripts to be used with [xfstest](https://github.com/kdave/xfstests). More details on the current bounds imposed by Ace and guidelines on workload generation can be found [here](docs/Ace.md).
 
-CrashMonkey and Ace can be used out of the box on any Linux filesystem that implements POSIX API. Our tools have been tested to work with ext2, ext3, ext4, xfs, F2FS, and btrfs, across Linux kernel versions - 3.12, 3.13, 3.16, 4.1, 4.4, 4.15, and 4.16.
+CrashMonkey and Ace can be used out of the box on any Linux filesystem that implements POSIX API. Our tools have been tested to work with ext2, ext3, ext4, xfs, F2FS, and btrfs, across Linux kernel versions - 3.12, 3.13, 3.16, 4.1, 4.4, 4.15, 4.16, and 5.5.
 
 ### Results ###
 We have tested four Linux file systems (ext4, xfs, btrfs, F2FS) and two verified file systems: [FCSQ](https://github.com/mit-pdos/fscq) and the [Yxv6](https://github.com/locore/yggdrasil) file system.

--- a/code/bio_alias.h
+++ b/code/bio_alias.h
@@ -58,20 +58,10 @@
 #define BIO_DISCARD_FLAG        REQ_OP_DISCARD
 #define BIO_IS_WRITE(bio)       op_is_write(bio_op(bio))
 
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) \
-  && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
-
-#define BI_RW                   bi_opf
-#define BI_DISK                 bi_disk
-#define BI_SIZE                 bi_iter.bi_size
-#define BI_SECTOR               bi_iter.bi_sector
-#define BIO_ENDIO(bio, err)     bio_endio(bio)
-#define BIO_IO_ERR(bio, err)    bio_io_error(bio)
-#define BIO_DISCARD_FLAG        REQ_OP_DISCARD
-#define BIO_IS_WRITE(bio)       op_is_write(bio_op(bio))
-
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) \
-  && LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)  \
+  && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)       \
+  && LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3))
 
 #define BI_RW                   bi_opf
 #define BI_DISK                 bi_disk

--- a/code/bio_alias.h
+++ b/code/bio_alias.h
@@ -70,6 +70,18 @@
 #define BIO_DISCARD_FLAG        REQ_OP_DISCARD
 #define BIO_IS_WRITE(bio)       op_is_write(bio_op(bio))
 
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) \
+  && LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)
+
+#define BI_RW                   bi_opf
+#define BI_DISK                 bi_disk
+#define BI_SIZE                 bi_iter.bi_size
+#define BI_SECTOR               bi_iter.bi_sector
+#define BIO_ENDIO(bio, err)     bio_endio(bio)
+#define BIO_IO_ERR(bio, err)    bio_io_error(bio)
+#define BIO_DISCARD_FLAG        REQ_OP_DISCARD
+#define BIO_IS_WRITE(bio)       op_is_write(bio_op(bio))
+
 #else
 #error "Unsupported kernel version: CrashMonkey has not been tested with " \
   "your kernel version."

--- a/xfsMonkey.py
+++ b/xfsMonkey.py
@@ -75,6 +75,11 @@ def print_setup(parsed_args):
 	print('{0:20}  {1}'.format('Test path', parsed_args.test_path))
 	print('\n{}\n'.format('=' * 48))
 
+def ensure_sudo():
+    if os.getuid() != 0:
+        print("Crashmonkey must be run with sudo!")
+        sys.exit(1)
+
 def validate_setup(parsed_args):
     if parsed_args.fs_type.lower() == "btrfs" and parsed_args.disk_size < 204800:
         print("Btrfs only supports Disk sizes >= 200 MB, but size is {} MB".format(
@@ -82,7 +87,7 @@ def validate_setup(parsed_args):
         sys.exit(1)
     if not parsed_args.test_path.endswith("/"):
         parsed_args.test_path += "/"
-
+    ensure_sudo()
 
 def main():
 


### PR DESCRIPTION
Includes changes to port crashmonkey. Manually verified that it builds and successfully can run xfsMonkey.py on both Linux 5.5.0 and Linux 5.5.2.