### PR TITLE
Port crashmonkey to Linux 5.6.0 - 5.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ CrashMonkey is a file-system agnostic record-replay-and-test framework. Unlike e
 ### Automatic Crash Explorer (Ace) ###
 Ace is an automatic workload generator, that exhaustively generates sequences of file-system operations (workloads), given certain bounds. Ace consists of a workload synthesizer that generates workloads in a high-level language which we call J-lang. A CrashMonkey adapter, that we built, converts these workloads into C++ test files that CrashMonkey can work with. We also have an XFSTest adapter that allows us to convert workloads into bash scripts to be used with [xfstest](https://github.com/kdave/xfstests). More details on the current bounds imposed by Ace and guidelines on workload generation can be found [here](docs/Ace.md).
 
-CrashMonkey and Ace can be used out of the box on any Linux filesystem that implements POSIX API. Our tools have been tested to work with ext2, ext3, ext4, xfs, F2FS, and btrfs, across Linux kernel versions - 3.12, 3.13, 3.16, 4.1, 4.4, 4.15, 4.16, and 5.5.
+CrashMonkey and Ace can be used out of the box on any Linux filesystem that implements POSIX API. Our tools have been tested to work with ext2, ext3, ext4, xfs, F2FS, and btrfs, across Linux kernel versions - 3.12, 3.13, 3.16, 4.1, 4.4, 4.15, 4.16, 5.5 and 5.6.
 
 ### Results ###
 We have tested four Linux file systems (ext4, xfs, btrfs, F2FS) and two verified file systems: [FCSQ](https://github.com/mit-pdos/fscq) and the [Yxv6](https://github.com/locore/yggdrasil) file system.

--- a/code/bio_alias.h
+++ b/code/bio_alias.h
@@ -61,7 +61,9 @@
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)  \
   && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)) || \
   (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)       \
-  && LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3))
+  && LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)       \
+  && LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
 
 #define BI_RW                   bi_opf
 #define BI_DISK                 bi_disk

--- a/code/cow_brd.c
+++ b/code/cow_brd.c
@@ -581,7 +581,9 @@ static struct brd_device *brd_alloc(int i)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 12, 0)
   brd->brd_queue->limits.discard_zeroes_data = 1;
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)
+     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
   blk_queue_flag_set(QUEUE_FLAG_DISCARD, brd->brd_queue);
 #else
   queue_flag_set_unlocked(QUEUE_FLAG_DISCARD, brd->brd_queue);
@@ -670,7 +672,9 @@ static struct kobject *brd_probe(dev_t dev, int *part, void *data)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 16, 0) && \
   LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0) || \
   LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)
+     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
   kobj = brd ? get_disk_and_module(brd->brd_disk) : NULL;
 #else
   kobj = brd ? get_disk(brd->brd_disk) : NULL;

--- a/code/disk_wrapper.c
+++ b/code/disk_wrapper.c
@@ -62,7 +62,9 @@ static struct hwm_device {
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0) || \
   (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-    LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3))
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
   struct gendisk* target_dev;
   u8 target_partno;
   struct block_device* target_bd;
@@ -135,7 +137,9 @@ static int disk_wrapper_ioctl(struct block_device* bdev, fmode_t mode,
         return -ENODATA;
       }
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-      LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3))
+      LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
       if (!access_ok((void*) arg,
 #else
       if (!access_ok(VERIFY_WRITE, (void*) arg,
@@ -161,7 +165,9 @@ static int disk_wrapper_ioctl(struct block_device* bdev, fmode_t mode,
         return -ENODATA;
       }
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-      LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3))
+      LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
       if (!access_ok((void*) arg,
 #else
       if (!access_ok(VERIFY_WRITE, (void*) arg,
@@ -478,7 +484,9 @@ static unsigned long long convert_flags(unsigned long long flags) {
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) \
     && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0) || \
       LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-      LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)
+      LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
 
   if ((flags & REQ_OP_MASK) == REQ_OP_WRITE) {
     res |= HWM_WRITE_FLAG;
@@ -556,7 +564,9 @@ static bool should_log(struct bio *bio) {
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) \
     && LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)) || \
       LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-      LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)
+      LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
   return
     ((bio->BI_RW & REQ_FUA) || (bio->BI_RW & REQ_PREFLUSH) ||
      (bio->BI_RW & REQ_OP_FLUSH) || (bio_op(bio) == REQ_OP_WRITE) ||
@@ -609,7 +619,9 @@ static void disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)) || \
      LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)
+     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
 static blk_qc_t disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
 #else
 #error "Unsupported kernel version: CrashMonkey has not been tested with " \
@@ -729,7 +741,9 @@ static blk_qc_t disk_wrapper_bio(struct request_queue* q, struct bio* bio) {
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0) || \
      LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)
+     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
   bio->bi_disk = hwm->target_dev;
   bio->bi_partno = hwm->target_partno;
   submit_bio(bio);
@@ -814,7 +828,9 @@ static int __init disk_wrapper_init(void) {
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0) || \
      LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)
+     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
   Device.target_dev = target_device->bd_disk;
   Device.target_partno = target_device->bd_partno;
   Device.target_bd = target_device;
@@ -923,7 +939,9 @@ static void __exit hello_cleanup(void) {
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
     LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0) || \
      LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && \
-     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3)
+     LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 3) || \
+  (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 7))
   blkdev_put(Device.target_bd, FMODE_READ);
 #else
 #error "Unsupported kernel version: CrashMonkey has not been tested with " \


### PR DESCRIPTION
Fixes #136 
Manually tested crashmonkey on kernel version 5.6.0 and 5.6.6.
Added the conditionals for versions in files
`bio_alias.h`, `disk_wrapper.c` and `cow_brd.c`.
Updated README.