### PR TITLE
Fix remove mod serialization.

### DIFF
--- a/code/utils/DiskMod.cpp
+++ b/code/utils/DiskMod.cpp
@@ -113,7 +113,8 @@ shared_ptr<char> DiskMod::Serialize(DiskMod &dm, unsigned long long *size) {
     }
 
     if (dm.mod_type == DiskMod::kFsyncMod ||
-        dm.mod_type == DiskMod::kCreateMod) {
+        dm.mod_type == DiskMod::kCreateMod ||
+        dm.mod_type == DiskMod::kRemoveMod) {
       return res_ptr;
     }
 


### PR DESCRIPTION
Don't overflow the buffer when serializing remove mods by skipping the
part that serialization information about file offsets and data.